### PR TITLE
feat: add project script to transform ttl to n-triples

### DIFF
--- a/config/odrl-parser/config.nt
+++ b/config/odrl-parser/config.nt
@@ -1,0 +1,150 @@
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb3> <http://www.w3.org/ns/shacl#minCount> "0"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://mu.semte.ch/vocabularies/ext/lmbMandatarisShape> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/shacl#NodeShape> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb21> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb11> <http://www.w3.org/ns/shacl#inversePath> <http://www.w3.org/ns/regorg#orgStatus> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb10> <http://www.w3.org/ns/shacl#path> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb11> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb25> <http://www.w3.org/ns/shacl#property> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb27> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb5> <http://www.w3.org/ns/shacl#minCount> "0"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForMandatarisOrg> <http://www.w3.org/ns/odrl/2/assigner> <http://mu.semte.ch/vocabularies/ext/lmbSystem> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb6> <http://www.w3.org/ns/shacl#property> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb7> .
+<http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty> <http://mu.semte.ch/vocabularies/ext/queryParameters> "session_role" .
+<http://mu.semte.ch/vocabularies/ext/lmbPublicSlice> <http://mu.semte.ch/vocabularies/ext/shaclShape> <http://mu.semte.ch/vocabularies/ext/lmbPublicShape> .
+<http://mu.semte.ch/vocabularies/ext/muAuthProfile> <http://purl.org/dc/terms/description> "ODRL profile describing access to mu-auth resources." .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb2> <http://www.w3.org/ns/shacl#property> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb4> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb24> <http://www.w3.org/ns/shacl#not> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb25> .
+<http://mu.semte.ch/vocabularies/ext/examplePolicyLMB> <http://www.w3.org/ns/odrl/2/permission> <http://mu.semte.ch/vocabularies/ext/allowReadForVendorOnMandatarisOrg> .
+<http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/PartyCollection> .
+<http://mu.semte.ch/vocabularies/ext/policeCouncilParty> <http://mu.semte.ch/vocabularies/ext/queryParameters> "session_group" .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb18> <http://www.w3.org/ns/shacl#path> <http://mu.semte.ch/vocabularies/ext/viewOnlyModules> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb28> <http://www.w3.org/ns/shacl#not> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb29> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb23> <http://www.w3.org/ns/shacl#path> <http://data.vlaanderen.be/ns/persoon#registratie> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb14> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb1> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForAuthenticatedOnViewOnlyModules> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/Permission> .
+<http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty> <http://purl.org/dc/terms/description> "This party collection represents all users who received the LoketLB-mandaatGebruiker role through ACM/IDM" .
+<http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicSlice> <http://www.w3.org/2006/vcard/ns#fn> "view-only-modules" .
+<http://mu.semte.ch/vocabularies/ext/allowReadForMandatarisOrg> <http://www.w3.org/ns/odrl/2/target> <http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb25> <http://www.w3.org/ns/shacl#property> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb26> .
+<http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice> <http://mu.semte.ch/vocabularies/ext/queryParameters> "session_group" .
+<http://mu.semte.ch/vocabularies/ext/allowReadForAuthenticatedOnViewOnlyModules> <http://www.w3.org/ns/odrl/2/target> <http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicSlice> .
+<http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty> <http://purl.org/dc/terms/description> "This party collection represents all users who can access the information regarding communes or OCMWs through their vendor api key" .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb2> <http://www.w3.org/ns/shacl#property> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb5> .
+<http://mu.semte.ch/vocabularies/ext/publicParty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/PartyCollection> .
+<http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/AssetCollection> .
+<http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty> <http://mu.semte.ch/vocabularies/ext/definedBy> "\n  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>\n  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>\n  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>\n  SELECT DISTINCT ?session_group ?session_role WHERE {\n    VALUES ?session {\n      <SESSION_ID>\n    }\n    {{\n      ?session muAccount:canActOnBehalfOf/mu:uuid ?session_group ;\n                    muAccount:account/ext:sessionRole ?session_role .\n    } UNION {\n      ?session muAccount:account ?account .\n      ?session muAccount:canActOnBehalfOf/ext:isOCMWVoor/mu:uuid ?session_group ;\n                              muAccount:account/ext:sessionRole ?session_role .\n      ?session muAccount:canActOnBehalfOf/ext:isOCMWVoor/^<http://lblod.data.gift/vocabularies/lmb/heeftBestuurseenheid>/<http://lblod.data.gift/vocabularies/lmb/hasStatus> <http://data.lblod.info/id/concept/InstallatievergaderingStatus/a40b8f8a-8de2-4710-8d9b-3fc43a4b740e> .\n      VALUES ?account {\n        <http://data.lblod.info/vendors/14db001d-ea0f-4a8a-8453-c48547347588> # Cipal\n        <http://data.lblod.info/vendors/42edb420-08c7-4ede-9961-bc0e527d0f3b> # Green Valley\n        <http://data.lblod.info/vendors/dc62419e-1267-44e7-9562-0114e2708b6f> # Remmicom\n      }\n    }}\n  }\n  " .
+<http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicShape> <http://www.w3.org/ns/shacl#property> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb18> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForMandatarisOrg> <http://www.w3.org/ns/odrl/2/assignee> <http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty> .
+<http://mu.semte.ch/vocabularies/ext/examplePolicyLMB> <http://www.w3.org/ns/odrl/2/permission> <http://mu.semte.ch/vocabularies/ext/allowWriteForMandatarisOrg> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForPublic> <http://www.w3.org/ns/odrl/2/target> <http://mu.semte.ch/vocabularies/ext/lmbPublicSlice> .
+<http://mu.semte.ch/vocabularies/ext/lmbSystem> <http://purl.org/dc/terms/description> "The LMB system party used as an assigner of the permission in this profile" .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb19> <http://www.w3.org/ns/shacl#targetClass> <http://data.vlaanderen.be/ns/mandaat#Mandataris> .
+<http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicSlice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/AssetCollection> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForMandatarisOrg> <http://www.w3.org/ns/odrl/2/action> <http://www.w3.org/ns/odrl/2/read> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForVendorOnMandatarisOrg> <http://www.w3.org/ns/odrl/2/assigner> <http://mu.semte.ch/vocabularies/ext/lmbSystem> .
+<http://mu.semte.ch/vocabularies/ext/examplePolicyLMB> <http://www.w3.org/ns/odrl/2/permission> <http://mu.semte.ch/vocabularies/ext/allowReadForPublic> .
+<http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty> <http://mu.semte.ch/vocabularies/ext/queryParameters> "session_role" .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb29> <http://www.w3.org/ns/shacl#property> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb30> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForPoliceCouncilOnMandatarisOrg> <http://www.w3.org/ns/odrl/2/assigner> <http://mu.semte.ch/vocabularies/ext/lmbSystem> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb6> <http://www.w3.org/ns/shacl#targetClass> <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid> .
+<http://mu.semte.ch/vocabularies/ext/muAuthProfile> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/Profile> .
+<http://mu.semte.ch/vocabularies/ext/examplePolicyLMB> <http://www.w3.org/ns/odrl/2/permission> <http://mu.semte.ch/vocabularies/ext/allowReadForMandatarisOrg> .
+<http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty> <http://www.w3.org/2006/vcard/ns#fn> "Vendor users" .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb1> <http://www.w3.org/ns/shacl#targetClass> <http://mu.semte.ch/vocabularies/ext/GeslachtCode> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb2> .
+<http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice> <http://purl.org/dc/terms/description> "This asset collection contains all information that is available to users with the LoketLB-mandaatGebruiker role in the context of the LMB app." .
+<http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice> <http://www.w3.org/2006/vcard/ns#fn> "organization-mandatendatabank" .
+<http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicShape> <http://www.w3.org/ns/shacl#targetClass> <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb2> <http://www.w3.org/ns/shacl#targetClass> <http://www.w3.org/2004/02/skos/core#ConceptScheme> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb34> .
+<http://mu.semte.ch/vocabularies/ext/examplePolicyLMB> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/Set> .
+<http://mu.semte.ch/vocabularies/ext/authenticatedParty> <http://www.w3.org/2006/vcard/ns#fn> "Authenticated user" .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb28> .
+<http://mu.semte.ch/vocabularies/ext/allowWriteForMandatarisOrg> <http://www.w3.org/ns/odrl/2/target> <http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForVendorOnMandatarisOrg> <http://www.w3.org/ns/odrl/2/target> <http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice> .
+<http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicSlice> <http://mu.semte.ch/vocabularies/ext/shaclShape> <http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicShape> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb2> <http://www.w3.org/ns/shacl#property> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb3> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForPoliceCouncilOnMandatarisOrg> <http://www.w3.org/ns/odrl/2/target> <http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice> .
+<http://mu.semte.ch/vocabularies/ext/policeCouncilParty> <http://www.w3.org/2006/vcard/ns#fn> "Politieraad lezer" .
+<http://mu.semte.ch/vocabularies/ext/policeCouncilParty> <http://purl.org/dc/terms/description> "This party collection represents all users who can access the information regarding police council mandates. This is defined by the members of communes that share the control of this police council." .
+<http://mu.semte.ch/vocabularies/ext/allowWriteForMandatarisOrg> <http://www.w3.org/ns/odrl/2/assignee> <http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty> .
+<http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty> <http://mu.semte.ch/vocabularies/ext/queryParameters> "session_group" .
+<http://mu.semte.ch/vocabularies/ext/allowWriteForMandatarisOrg> <http://www.w3.org/ns/odrl/2/action> <http://www.w3.org/ns/odrl/2/modify> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForVendorOnMandatarisOrg> <http://www.w3.org/ns/odrl/2/action> <http://www.w3.org/ns/odrl/2/read> .
+<http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice> <http://mu.semte.ch/vocabularies/ext/graphPrefix> <http://mu.semte.ch/graphs/organizations/> .
+<http://mu.semte.ch/vocabularies/ext/lmbPublicShape> <http://www.w3.org/ns/shacl#or> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb14> .
+<http://mu.semte.ch/vocabularies/ext/lmbSystem> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/Party> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForPublic> <http://www.w3.org/ns/odrl/2/action> <http://www.w3.org/ns/odrl/2/read> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb8> <http://www.w3.org/ns/shacl#inversePath> <http://mu.semte.ch/vocabularies/ext/all> .
+<http://mu.semte.ch/vocabularies/ext/policeCouncilParty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/PartyCollection> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForPublic> <http://www.w3.org/ns/odrl/2/assigner> <http://mu.semte.ch/vocabularies/ext/lmbSystem> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb26> <http://www.w3.org/ns/shacl#path> <http://data.vlaanderen.be/ns/persoon#registratie> .
+<http://mu.semte.ch/vocabularies/ext/authenticatedParty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/PartyCollection> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb21> <http://www.w3.org/ns/shacl#not> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb22> .
+<http://mu.semte.ch/vocabularies/ext/lmbPublicSlice> <http://purl.org/dc/terms/description> "This asset collection contains all information that is available to the public in the context of the LMB app." .
+<http://mu.semte.ch/vocabularies/ext/examplePolicyLMB> <http://www.w3.org/ns/odrl/2/permission> <http://mu.semte.ch/vocabularies/ext/allowReadForAuthenticatedOnViewOnlyModules> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb33> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb20> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb33> .
+<http://mu.semte.ch/vocabularies/ext/publicParty> <http://purl.org/dc/terms/description> "This party represent all (possibly not logged in) users of the system." .
+<http://mu.semte.ch/vocabularies/ext/publicParty> <http://mu.semte.ch/vocabularies/ext/definedBy> "\n  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>\n  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>\n  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>\n  SELECT DISTINCT * WHERE {\n    VALUES ?session {\n      <SESSION_ID>\n    }\n    ?session a ?thing .\n  }\n  " .
+<http://mu.semte.ch/vocabularies/ext/allowReadForVendorOnMandatarisOrg> <http://www.w3.org/ns/odrl/2/assignee> <http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb17> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb9> <http://www.w3.org/ns/shacl#property> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb12> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb34> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb35> .
+<http://mu.semte.ch/vocabularies/ext/authenticatedParty> <http://mu.semte.ch/vocabularies/ext/definedBy> "\n  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>\n  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>\n  SELECT DISTINCT ?session_group ?session_role WHERE {\n    <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group ;\n                 ext:sessionRole ?session_role .\n  }\n  " .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb16> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb32> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb19> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb9> .
+<http://mu.semte.ch/vocabularies/ext/examplePolicyLMB> <http://www.w3.org/ns/odrl/2/profile> <http://mu.semte.ch/vocabularies/ext/muAuthProfile> .
+<http://mu.semte.ch/vocabularies/ext/policeCouncilParty> <http://mu.semte.ch/vocabularies/ext/definedBy> "\n  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>\n  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>\n  SELECT DISTINCT ?session_group ?session_role WHERE {\n    <SESSION_ID> ext:sessionGroup ?original_session_group ;\n                  ext:sessionRole ?session_role .\n    ?original_session_group ext:deeltBestuurVan/mu:uuid ?session_group .\n\n    FILTER( ?session_role = \"LoketLB-mandaatGebruiker\" )\n  }\n  " .
+<http://mu.semte.ch/vocabularies/ext/lmbPublicSlice> <http://www.w3.org/2006/vcard/ns#fn> "public" .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb17> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForVendorOnMandatarisOrg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/Permission> .
+<http://mu.semte.ch/vocabularies/ext/vendorGebruikerParty> <http://mu.semte.ch/vocabularies/ext/queryParameters> "session_group" .
+<http://mu.semte.ch/vocabularies/ext/allowReadForPublic> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/Permission> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb30> <http://www.w3.org/ns/shacl#path> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb31> .
+<http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicSlice> <http://purl.org/dc/terms/description> "This asset collection contains all information that is available to all authenticated users in the context of the LMB app." .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb36> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb28> <http://www.w3.org/ns/shacl#targetClass> <http://data.vlaanderen.be/ns/persoon#Persoon> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForMandatarisOrg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/Permission> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForAuthenticatedOnViewOnlyModules> <http://www.w3.org/ns/odrl/2/action> <http://www.w3.org/ns/odrl/2/read> .
+<http://mu.semte.ch/vocabularies/ext/authenticatedParty> <http://purl.org/dc/terms/description> "This represents all logged in users of the system." .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb27> <http://www.w3.org/ns/shacl#path> <http://data.vlaanderen.be/ns/persoon#heeftGeboorte> .
+<http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicSlice> <http://mu.semte.ch/vocabularies/ext/graphPrefix> <http://mu.semte.ch/graphs/authenticated/public> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb12> <http://www.w3.org/ns/shacl#path> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb13> .
+<http://mu.semte.ch/vocabularies/ext/policeCouncilParty> <http://mu.semte.ch/vocabularies/ext/queryParameters> "session_role" .
+<http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice> <http://mu.semte.ch/vocabularies/ext/shaclShape> <http://mu.semte.ch/vocabularies/ext/lmbMandatarisShape> .
+<http://mu.semte.ch/vocabularies/ext/examplePolicyLMB> <http://www.w3.org/ns/odrl/2/permission> <http://mu.semte.ch/vocabularies/ext/allowReadForPoliceCouncilOnMandatarisOrg> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb4> <http://www.w3.org/ns/shacl#path> <http://www.w3.org/2004/02/skos/core#prefLabel> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb13> <http://www.w3.org/ns/shacl#inversePath> <http://lblod.data.gift/vocabularies/lmb/InstallatievergaderingStatus> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForAuthenticatedOnViewOnlyModules> <http://www.w3.org/ns/odrl/2/assignee> <http://mu.semte.ch/vocabularies/ext/authenticatedParty> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb5> <http://www.w3.org/ns/shacl#path> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb9> <http://www.w3.org/ns/shacl#property> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb10> .
+<http://mu.semte.ch/vocabularies/ext/lmbMandatarisShape> <http://www.w3.org/ns/shacl#or> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb32> .
+<http://mu.semte.ch/vocabularies/ext/lmbOrganizationMandatesSlice> <http://mu.semte.ch/vocabularies/ext/queryParameters> "session_role" .
+<http://mu.semte.ch/vocabularies/ext/lmbAuthenticatedPublicShape> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/shacl#NodeShape> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForPoliceCouncilOnMandatarisOrg> <http://www.w3.org/ns/odrl/2/action> <http://www.w3.org/ns/odrl/2/read> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb24> <http://www.w3.org/ns/shacl#targetClass> <http://data.vlaanderen.be/ns/persoon#Persoon> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb22> <http://www.w3.org/ns/shacl#property> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb23> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb7> <http://www.w3.org/ns/shacl#path> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb8> .
+<http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/PartyCollection> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb4> <http://www.w3.org/ns/shacl#minCount> "0"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb3> <http://www.w3.org/ns/shacl#path> <http://www.w3.org/2004/02/skos/core#inScheme> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForPublic> <http://www.w3.org/ns/odrl/2/assignee> <http://mu.semte.ch/vocabularies/ext/publicParty> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb14> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb15> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForPoliceCouncilOnMandatarisOrg> <http://www.w3.org/ns/odrl/2/assignee> <http://mu.semte.ch/vocabularies/ext/policeCouncilParty> .
+<http://mu.semte.ch/vocabularies/ext/allowWriteForMandatarisOrg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/Permission> .
+<http://mu.semte.ch/vocabularies/ext/lmbPublicSlice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/AssetCollection> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb20> <http://www.w3.org/ns/shacl#targetClass> <http://data.vlaanderen.be/ns/mandaat#Fractie> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb9> <http://www.w3.org/ns/shacl#targetClass> <http://www.w3.org/2004/02/skos/core#Concept> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb21> <http://www.w3.org/ns/shacl#targetClass> <http://data.vlaanderen.be/ns/persoon#Persoon> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb16> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb6> .
+<http://mu.semte.ch/vocabularies/ext/allowReadForPoliceCouncilOnMandatarisOrg> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/odrl/2/Permission> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb36> .
+<http://mu.semte.ch/vocabularies/ext/publicParty> <http://www.w3.org/2006/vcard/ns#fn> "Public user" .
+<http://mu.semte.ch/vocabularies/ext/lmbSystem> <http://www.w3.org/2006/vcard/ns#fn> "LMB System" .
+<http://mu.semte.ch/vocabularies/ext/lmbPublicSlice> <http://mu.semte.ch/vocabularies/ext/graphPrefix> <http://mu.semte.ch/graphs/public> .
+<http://mu.semte.ch/vocabularies/ext/lmbPublicShape> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/shacl#NodeShape> .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb31> <http://www.w3.org/ns/shacl#inversePath> <http://data.vlaanderen.be/ns/mandaat#isBestuurlijkeAliasVan> .
+<http://mu.semte.ch/vocabularies/ext/allowWriteForMandatarisOrg> <http://www.w3.org/ns/odrl/2/assigner> <http://mu.semte.ch/vocabularies/ext/lmbSystem> .
+<http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty> <http://mu.semte.ch/vocabularies/ext/definedBy> "\n  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>\n  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>\n  SELECT DISTINCT ?session_group ?session_role WHERE {\n    <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group ;\n                  ext:sessionRole ?session_role .\n    FILTER( ?session_role = \"LoketLB-mandaatGebruiker\" )\n  }\n  " .
+<http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb35> <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://lblod.data.gift/bnode/nd5733fd560c44ad6a7f66569b7604e5eb24> .
+<http://mu.semte.ch/vocabularies/ext/mandaatGebruikerParty> <http://www.w3.org/2006/vcard/ns#fn> "Mandaten users" .

--- a/config/odrl-parser/config.ttl
+++ b/config/odrl-parser/config.ttl
@@ -1,0 +1,312 @@
+# ODRL policy in ttl format corresponding. This policy matches the simplified
+# LMB authorisation policy in the lisp file.
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/>.
+@prefix odrl: <http://www.w3.org/ns/odrl/2/>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix lmb: <http://lblod.data.gift/vocabularies/lmb/>.
+@prefix besluit: <http://data.vlaanderen.be/ns/besluit#>.
+@prefix regorg: <http://www.w3.org/ns/regorg#>.
+@prefix persoon: <http://data.vlaanderen.be/ns/persoon#>.
+
+# TODO: Extend with extra `ext:*` elements?
+ext:muAuthProfile a odrl:Profile ;
+  dct:description "ODRL profile describing access to mu-auth resources." .
+
+ext:examplePolicyLMB a odrl:Set ;
+  odrl:profile ext:muAuthProfile ;
+  odrl:permission ext:allowReadForPublic ,
+    ext:allowReadForMandatarisOrg ,
+    ext:allowWriteForMandatarisOrg ,
+    ext:allowReadForVendorOnMandatarisOrg ,
+    ext:allowReadForPoliceCouncilOnMandatarisOrg ,
+    ext:allowReadForAuthenticatedOnViewOnlyModules .
+
+# parties
+ext:lmbSystem a odrl:Party ;
+  vcard:fn "LMB System" ;
+  # no query here so no users match
+  # TODO: Use sparql-parser's 'NEVER' constraint to ensure group is not used in
+  # configuration?
+  dct:description "The LMB system party used as an assigner of the permission in this profile" .
+
+ext:publicParty a odrl:PartyCollection ;
+  vcard:fn "Public user" ;
+  # NOTE (20/08/2025): Ideally it should not be necessary to add this as it will
+  # not be used in the sparql-parser configuration. Is it necessary to
+  # differentiate between this case, which is "all users", and the above system
+  # party, which is "no users"?
+  #
+  # this query matches every session and has no parameters
+  ext:definedBy """
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT DISTINCT * WHERE {
+    VALUES ?session {
+      <SESSION_ID>
+    }
+    ?session a ?thing .
+  }
+  """ ;
+  dct:description "This party represent all (possibly not logged in) users of the system." .
+
+ext:authenticatedParty a odrl:PartyCollection ;
+  vcard:fn "Authenticated user" ;
+  # no `ext:queryParameters` as they will not be used for this party
+  ext:definedBy """
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT DISTINCT ?session_group ?session_role WHERE {
+    <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group ;
+                 ext:sessionRole ?session_role .
+  }
+  """ ;
+  dct:description "This represents all logged in users of the system." .
+
+ext:mandaatGebruikerParty a odrl:PartyCollection ;
+  vcard:fn "Mandaten users" ;
+  ext:definedBy """
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT DISTINCT ?session_group ?session_role WHERE {
+    <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group ;
+                  ext:sessionRole ?session_role .
+    FILTER( ?session_role = \"LoketLB-mandaatGebruiker\" )
+  }
+  """ ;
+  ext:queryParameters "session_group", "session_role" ;
+  dct:description "This party collection represents all users who received the LoketLB-mandaatGebruiker role through ACM/IDM" .
+
+ext:vendorGebruikerParty a odrl:PartyCollection ;
+  vcard:fn "Vendor users" ;
+  ext:definedBy """
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT DISTINCT ?session_group ?session_role WHERE {
+    VALUES ?session {
+      <SESSION_ID>
+    }
+    {{
+      ?session muAccount:canActOnBehalfOf/mu:uuid ?session_group ;
+                    muAccount:account/ext:sessionRole ?session_role .
+    } UNION {
+      ?session muAccount:account ?account .
+      ?session muAccount:canActOnBehalfOf/ext:isOCMWVoor/mu:uuid ?session_group ;
+                              muAccount:account/ext:sessionRole ?session_role .
+      ?session muAccount:canActOnBehalfOf/ext:isOCMWVoor/^<http://lblod.data.gift/vocabularies/lmb/heeftBestuurseenheid>/<http://lblod.data.gift/vocabularies/lmb/hasStatus> <http://data.lblod.info/id/concept/InstallatievergaderingStatus/a40b8f8a-8de2-4710-8d9b-3fc43a4b740e> .
+      VALUES ?account {
+        <http://data.lblod.info/vendors/14db001d-ea0f-4a8a-8453-c48547347588> # Cipal
+        <http://data.lblod.info/vendors/42edb420-08c7-4ede-9961-bc0e527d0f3b> # Green Valley
+        <http://data.lblod.info/vendors/dc62419e-1267-44e7-9562-0114e2708b6f> # Remmicom
+      }
+    }}
+  }
+  """ ;
+  ext:queryParameters "session_group", "session_role" ;
+  dct:description "This party collection represents all users who can access the information regarding communes or OCMWs through their vendor api key" .
+
+ext:policeCouncilParty a odrl:PartyCollection ;
+  vcard:fn "Politieraad lezer" ;
+  ext:definedBy """
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  SELECT DISTINCT ?session_group ?session_role WHERE {
+    <SESSION_ID> ext:sessionGroup ?original_session_group ;
+                  ext:sessionRole ?session_role .
+    ?original_session_group ext:deeltBestuurVan/mu:uuid ?session_group .
+
+    FILTER( ?session_role = \"LoketLB-mandaatGebruiker\" )
+  }
+  """ ;
+  ext:queryParameters "session_group", "session_role" ;
+  dct:description "This party collection represents all users who can access the information regarding police council mandates. This is defined by the members of communes that share the control of this police council." .
+
+
+# graphs
+ext:lmbPublicSlice a odrl:AssetCollection ;
+  vcard:fn "public" ;
+  # no query parameters added to the group so the graph is exactly this uri
+  ext:graphPrefix <http://mu.semte.ch/graphs/public> ;
+  ext:shaclShape ext:lmbPublicShape ;
+  dct:description "This asset collection contains all information that is available to the public in the context of the LMB app." .
+
+ext:lmbAuthenticatedPublicSlice a odrl:AssetCollection ;
+  vcard:fn "view-only-modules" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/authenticated/public> ;
+  ext:shaclShape ext:lmbAuthenticatedPublicShape ;
+  dct:description "This asset collection contains all information that is available to all authenticated users in the context of the LMB app." .
+
+ext:lmbOrganizationMandatesSlice a odrl:AssetCollection ;
+vcard:fn "organization-mandatendatabank" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/organizations/> ;
+  # TODO: Can we avoid having to specify these parameters again?
+  ext:queryParameters "session_group", "session_role" ;
+  ext:shaclShape ext:lmbMandatarisShape ;
+  dct:description "This asset collection contains all information that is available to users with the LoketLB-mandaatGebruiker role in the context of the LMB app." .
+
+
+# rules
+ext:allowReadForPublic a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:lmbPublicSlice ;
+  # NOTE (20/08/2025): For the transformation to sparql-parser we can ignore
+  # this the `odrl:assigner` property. It is an optional property for
+  # `odrl:Permission`s and as sparql-parser has no such notion it will not be
+  # used in the generated configuration.
+  odrl:assigner ext:lmbSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForAuthenticatedOnViewOnlyModules a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:lmbAuthenticatedPublicSlice ;
+  odrl:assignee ext:authenticatedParty .
+
+# NOTE (20/08/2025): ODRL requires exactly 1 action per Rule (Permission). So
+# read and write access must be specified with separate permissions. The
+# transformation to sparql-parser will probably have to merge these to a single
+# grant with read and write rights.
+ext:allowReadForMandatarisOrg a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target  ext:lmbOrganizationMandatesSlice ;
+  odrl:assigner ext:lmbSystem ;
+  odrl:assignee ext:mandaatGebruikerParty .
+
+ext:allowWriteForMandatarisOrg a odrl:Permission ;
+  # NOTE (19/08/2025): Strictly speaking `odrl:modify` does *not* cover the
+  # creation of new assets, new assets can be `odrl:extract`ed or `odrl:derive`d
+  # from existing ones. But creating a completely new asset does not seem to be
+  # covered by ODRL.
+  odrl:action odrl:modify ; # NOTE (13/08/2025): The `odrl:write` property was deprecated in favour of `odrl:modify`
+  odrl:target ext:lmbOrganizationMandatesSlice;
+  odrl:assigner ext:lmbSystem ;
+  odrl:assignee ext:mandaatGebruikerParty .
+
+ext:allowReadForVendorOnMandatarisOrg a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:lmbOrganizationMandatesSlice ;
+  odrl:assigner ext:lmbSystem ;
+  odrl:assignee ext:vendorGebruikerParty .
+
+ext:allowReadForPoliceCouncilOnMandatarisOrg a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:lmbOrganizationMandatesSlice ;
+  odrl:assigner ext:lmbSystem ;
+  odrl:assignee ext:policeCouncilParty .
+
+
+# shapes
+## public shape
+ext:lmbPublicShape a sh:NodeShape ;
+  # showing only a few types to keep the sample small
+  sh:or (
+    [
+    # ("ext:GeslachtCode" -> _)
+      sh:targetClass ext:GeslachtCode ;
+    ]
+    [
+    # Fictional example for a shape where the predicates matter. Users can
+    # access only `skos:inScheme`, `skos:prefLabel`, and `rdf:type` triples for
+    # `skos:ConceptScheme` resources.
+    # ("skos:ConceptScheme" -> "skos:inScheme"
+    #                       -> "skos:prefLabel"
+    #                       -> "rdf:type")
+      sh:targetClass skos:ConceptScheme ;
+      sh:property [
+        sh:path skos:inScheme ;
+        sh:minCount 0 # NOTE (19/08/2025): What is the added value of this for generating authz rules?
+      ], [
+        sh:path skos:prefLabel ;
+        sh:minCount 0
+      ], [
+        sh:path rdf:type ;
+        sh:minCount 0
+      ]
+    ]
+    [
+    # Fictional example to illustrate an inverse predicate specification. Users
+    # can access all triples with a `besluit:Bestuurseenheid` as object.
+    # ("besluit:Bestuurseenheid" <- _)
+      sh:targetClass besluit:Bestuurseenheid ;
+      sh:property [
+        sh:path [ sh:inversePath ext:all ] # define custom predicate that should be interpreted as sparql-parser's `_`
+      ]
+    ]
+    [
+    # Fictional example to illustrate a selective inverse predicate
+    # specification. For `skos:Concept` resources users can only access
+    # `regorg:orgStatus` and `lmb:InstallatievergaderingStatus` triples in such
+    # a resource is the object.
+    # ("skos:Concept" <- "regorg:orgStatus"
+    #                 <- "lmb:InstallatievergaderingStatus")
+      sh:targetClass skos:Concept ;
+      sh:property [
+        sh:path [ sh:inversePath regorg:orgStatus ]
+      ], [
+        sh:path [ sh:inversePath lmb:InstallatievergaderingStatus]
+      ]
+    ]
+  ).
+
+## authenticated public shape
+ext:lmbAuthenticatedPublicShape a sh:NodeShape ;
+  sh:targetClass besluit:Bestuurseenheid ;
+  sh:property [ sh:path ext:viewOnlyModules ] .
+
+## mandate shape
+ext:lmbMandatarisShape a sh:NodeShape ;
+  # showing only a few types to keep the sample small
+  sh:or (
+    [
+    # ("mandaat:Mandataris" -> _)
+      sh:targetClass mandaat:Mandataris
+    ]
+    [
+    # ("mandaat:Fractie" -> _)
+      sh:targetClass mandaat:Fractie
+    ]
+    [
+    # Fictional example to illustrate a disallow predicate specification. Users
+    # can access everything for a `persoon:Persoon` except their
+    # `persoon:registratie`.
+    # ("persoon:Persoon" x> "persoon:registratie")
+      sh:targetClass persoon:Persoon ;
+      sh:not [
+        sh:property [
+          sh:path persoon:registratie
+        ]
+      ]
+    ]
+    [
+    # Fictional example to illustrate a disallow predicate specification with
+    # multiple predicates. Users can access everything for a `persoon:Persoon`
+    # except their `persoon:registratie` or `persoon:heeftGeboorte`.
+    # ("persoon:Persoon" x> "persoon:registratie"
+    #                    x> "persoon:heeftGeboorte")
+      sh:targetClass persoon:Persoon ;
+      sh:not [
+        sh:property [
+          sh:path persoon:registratie
+        ], [
+          sh:path persoon:heeftGeboorte
+        ]
+      ]
+    ]
+    [
+    # Fictional example to illustrate a disallow inverse predicate
+    # specification. Users cannot access `mandaat:isBestuurlijkeAliasVan`
+    # triples with a `persoon:Persoon` as object.
+    # ("persoon:Persoon" <x "mandaat:isBestuurlijkeAliasVan")
+      sh:targetClass persoon:Persoon ;
+      sh:not [
+        sh:property [
+          sh:path [ sh:inversePath mandaat:isBestuurlijkeAliasVan ]
+        ]
+      ]
+    ]
+  ).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,3 +55,8 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  project-scripts:
+    image: semtech/simple-script-store:1.0.0
+    volumes:
+      - ./scripts/:/app/scripts/
+    restart: "no"

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.1",
+  "scripts": [
+    {
+      "documentation": {
+        "command": "ttl-to-ntriples",
+        "description": "Convert a ttl-files to corresponding n-triple files.",
+        "arguments": ["-r", "--replace"]
+      },
+      "environment": {
+        "image": "python:3.13.7",
+        "interactive": false,
+        "script": "ttl-to-ntriples/run.sh"
+      },
+      "mounts": {
+        "app": "/app/"
+      }
+    }
+  ]
+}

--- a/scripts/ttl-to-ntriples/run.sh
+++ b/scripts/ttl-to-ntriples/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+
+pip install rdflib argparse
+python ttl-to-ntriples.py $1

--- a/scripts/ttl-to-ntriples/ttl-to-ntriples.py
+++ b/scripts/ttl-to-ntriples/ttl-to-ntriples.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+
+import os
+import argparse
+from rdflib import Graph
+
+# NOTE (05/09/2025): To further generalise this script, this constant should be
+# made into a argument that can be passed by the caller.
+CONFIG_PATH = "/app/config/odrl-parser/"
+TTL_EXT = ".ttl"
+NTRIPLES_EXT = ".nt"
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-r", "--replace", action="store_true")
+args = parser.parse_args()
+
+if os.path.isdir(CONFIG_PATH):
+    os.chdir(CONFIG_PATH)
+    for file in os.listdir():
+        target = file.replace(TTL_EXT, NTRIPLES_EXT)
+        if file.endswith(TTL_EXT) and (args.replace or not os.path.exists(target)):
+            print(" >> Found " + file)
+            graph = Graph()
+            graph.parse(file, format="turtle")
+            graph = graph.skolemize(basepath="http://lblod.data.gift/bnode/")
+            graph.serialize(format="nt11", destination=target)
+            print(" >> Wrote " + target)
+else:
+    print(" >> Error: path does not exist: ", CONFIG_PATH)


### PR DESCRIPTION
This adds a project script to the add that allows to convert turtle files into their corresponding n-triples files.

This script is to be used as part of a workaround for the [odrl-parser](https://github.com/lblod/odrl-parser-service) service[^1] to allow it to process files containing ODRL policies. Ideally that service would directly read from turtle files. But the service is written in common lisp[^2] and there is currently no turtle parser available in that language. In anticipation of a turtle parser, we opted to read ODRL policies as n-triples, for which there is a parser available. To avoid having to actually write policies as n-triples this script can be used to automatically convert ODRL policies in turtle to n-triples.

The script will look for turtle files in `config/odrl-parser/`[^3] and write the generated n-triples files to the same directory. The file names of the generated files are taken from the source files.

## How to test
Run the script with the following command[^4]:

``` shell
mu script project-scripts ttl-to-ntriples
```

By default, the script does *not* overwrite already existing files, it simply skips turtle files for which there already exists an n-triples file with the same name. This behaviour can be changed by providing the `-r` (or `--replace`) flag to the script to instruct it to overwrite any existing files:

``` shell
mu script project-scripts ttl-to-ntriples --replace
```

## Notes
- The `CONFIG_PATH` from which input files are read is currently hardcoded. Should this script be used in other contexts this can be made configurable.
- The replace behaviour is intentionally kept as simple as possible: simply overwrite any existing file with the same name. It will not ask for confirmation, allow to append instead, or other fancy stuff.

## Related tickets
- LBRON-328


[^1]: A service, currently under development, that translates ODRL policies into authorisation configurations for [sparql-parser](https://github.com/mu-semtech/sparql-parser).

[^2]: Common lisp was choosen to facilitate future integration with sparql-parser.

[^3]: This path is currently hardcoded and is the location from where the odrl-parser service reads its ODRL policies from.

[^4]: Here `mu` refers to [mu-cli](https://github.com/mu-semtech/mu-cli) which should be installed on your machine for this to work.