### PR TITLE
chore: add CHANGELOG file for app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+## Unreleased
+### Backend
+- Add the `projects-scripts` service to allow writing and executing project-specific scripts. [LBRON-328]
+
+### Deploy notes
+- `drc pull project-scripts; drc up -d project-scripts`


### PR DESCRIPTION
In other apps there is a habit to keep an explicit changelog which, among other things, documents the steps to follow to deploy a release.  In the past I found this rather handy, especially if multiple people contributed to a single release (and/or too much time has passed since deploying to DEV for my memory to recall what I did at the time.)

I would propose we also do this for this app. Although, it will probably be less crucial here due to the POC-nature of the app, with possibly few (if any) releases. The idea would be that
- As part of each PR one updates the changelog accordingly. More specifically, add the appropriate entries to the "Unreleased" section.
- When doing a release one moves the contents of the "Unreleased" to a release section, typically titled like "vX.Y.Z (release date)". Afterwards, commit and tag accordingly.

In this PR I added a small example of what an entry would be for the functionality added in another [PR](https://github.com/lblod/app-decide/pull/2). Some examples of more extensive changelogs can be, for example, found in [Digitaal Loket](https://github.com/lblod/app-digitaal-loket/blob/development/CHANGELOG.md) or [OrganisatiePortaal](https://github.com/lblod/app-organization-portal/blob/development/CHANGELOG.md).