### PR TITLE
feat: add odrl-parser service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,3 +60,7 @@ services:
     volumes:
       - ./scripts/:/app/scripts/
     restart: "no"
+  odrl-parser:
+    image: lblod/odrl-parser-service:0.0.1
+    volumes:
+      - ./config/odrl-parser:/config


### PR DESCRIPTION
This service allows to generate sparql-parser configurations from ODRL
policies. See the service for more information on its usage.

## How to test
1. Switch to this PR's branch. Launch the app as usual or `pull` and `up` the added `odrl-parser` service if the app is already running.
2. Load the ODRL policy defined in `config/odrl-parser/config.nt`[^1] into the triplestore using `docker compose exec odrl-parser curl http://localhost/load-policy` Do **not** change the file name of the input file, the service currently only reads from that specific file.
3. The policy data should be inserted into the `<http://mu.semte.ch/graphs/odrl-policy>` graph. Best to quickly query the graph to check.
4. To generate a sparql-parser configuration from the loaded example policy execute `docker compose exec odrl-parser curl http://localhost/generate-config`. The generated configuration should be written to `config/odrl-parser/examplePolicyLMB.lisp`[^2].


[^1]: If this file does not yet exist, you can generate one from `config.ttl` in the same folder using the project script `ttl-to-ntriples`. See this [PR](https://github.com/lblod/app-decide/pull/2) for more background on this script.

[^2]: The file name is based on the affix of the URI of the policy resource in the input ODRL policy. If that was modified for some reason the file name will be different.