### PR TITLE
chore(sparql-parser): bump service to v0.0.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,6 @@ services:
       - ./scripts/:/app/scripts/
     restart: "no"
   odrl-parser:
-    image: lblod/odrl-parser-service:0.0.2
+    image: lblod/odrl-parser-service:0.0.3
     volumes:
       - ./config/odrl-parser:/config


### PR DESCRIPTION
This [release](https://github.com/lblod/odrl-parser-service/blob/master/CHANGELOG.md#v003-2025-10-15) of the service introduces
- live reloading to simplify development
- improve generated configuration with prefixes