### PR TITLE
Add `vc-issuer` dispatcher for `/sessions/current`

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -49,6 +49,11 @@ defmodule Dispatcher do
   #################
   # by setting an ISSUER_URL with a path component, we can in theory host multiple issuers on the same domain.
   # it does require fiddling a bit with the 'well known paths' though.
+
+  match "/vc-verifier/sessions/*path", %{ layer: :static, accept: [:any]} do
+    Proxy.forward conn, path, "http://vc-issuer/sessions/"
+  end
+
    match "/vc-verifier/*path", %{ accept: [:any], layer: :static } do
     Proxy.forward conn, path, "http://vc-issuer/verifier/"
   end


### PR DESCRIPTION
When logging in through VC, the `GET` and `DELETE` actions on `/sessions/current` need to be exposed so that `mu-session-auth` can later use them to log in/log out on the frontend.

## Links to other PRs

- https://github.com/lblod/frontend-decide/pull/5
- https://github.com/lblod/oid4vc-login-service/pull/3