### PR TITLE
Consume Lokaal Beslist dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,15 @@ This should be your go-to way of starting the stack.
 ```bash
 docker compose up -d # run without -d flag when you don't want to run it in the background
 ```
+
+### Consuming decisions
+
+Decision data from Lokaal Beslist is ingested by a consumer. The initial sync and/or delta ingest should be enabled manually in `docker-compose.override.yml`:
+
+```yml
+services:
+  lokaal-beslist-consumer:
+    environment:
+      DCR_DISABLE_INITIAL_SYNC: false
+      DCR_DISABLE_DELTA_INGEST: false
+```

--- a/config/virtuoso/virtuoso.ini
+++ b/config/virtuoso/virtuoso.ini
@@ -37,7 +37,7 @@ TempStorage			= TempDatabase
 [TempDatabase]
 DatabaseFile			= /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso-temp.db
 TransactionFile			= /usr/local/virtuoso-opensource/var/lib/virtuoso/db/virtuoso-temp.trx
-MaxCheckpointRemap		= 2000
+MaxCheckpointRemap		= 4000
 Striping			= 0
 
 
@@ -77,7 +77,7 @@ MaxMemPoolSize                  = 200000000
 PrefixResultNames               = 0
 MacSpotlight                    = 0
 IndexTreeMaps                   = 64
-MaxQueryMem 		 	= 2G		; memory allocated to query processor
+MaxQueryMem 		 	= 4G		; memory allocated to query processor
 VectorSize 		 	= 1000		; initial parallel query vector (array of query operations) size
 MaxVectorSize 		 	= 1000000	; query vector size threshold.
 AdjustVectorSize 	 	= 0
@@ -113,8 +113,8 @@ AsyncQueueMaxThreads 	 	= 10
 ;; Note the default settings will take very little memory
 ;; but will not result in very good performance
 ;;
-NumberOfBuffers          = 10000
-MaxDirtyBuffers          = 6000
+NumberOfBuffers          = 680000
+MaxDirtyBuffers          = 500000
 
 
 [HTTPServer]
@@ -236,10 +236,10 @@ DefaultHost			= localhost:8890
 ;ExternalXsltSource 		= 1
 ;DefaultGraph      		= http://localhost:8890/dataspace
 ;ImmutableGraphs    		= http://localhost:8890/dataspace
-ResultSetMaxRows           	= 10000
-MaxConstructTriples      	  = 10000
-MaxQueryCostEstimationTime 	= 400	; in seconds
-MaxQueryExecutionTime      	= 60	; in seconds
+ResultSetMaxRows           	= 10000000
+MaxConstructTriples      	  = 10000000
+MaxQueryCostEstimationTime 	= 4000	; in seconds
+MaxQueryExecutionTime      	= 1200	; in seconds
 DefaultQuery               	= select distinct ?Concept where {[] a ?Concept} LIMIT 100
 DeferInferenceRulesInit    	= 0  ; controls inference rules loading
 MaxMemInUse			= 0  ; limits the amount of memory for construct dict (0=unlimited)
@@ -260,3 +260,6 @@ LoadPath			= /usr/local/virtuoso-opensource/lib/virtuoso/hosting
 ;Load10		= Hosting,hosting_python.so
 ;Load11		= Hosting,hosting_ruby.so
 ;Load12				= msdtc,msdtc_sample
++Load6           = plain, proj4
++Load7           = plain, geos
++Load8           = plain, shapefileio

--- a/config/virtuoso/virtuoso.ini
+++ b/config/virtuoso/virtuoso.ini
@@ -236,7 +236,7 @@ DefaultHost			= localhost:8890
 ;ExternalXsltSource 		= 1
 ;DefaultGraph      		= http://localhost:8890/dataspace
 ;ImmutableGraphs    		= http://localhost:8890/dataspace
-ResultSetMaxRows           	= 10000000
+ResultSetMaxRows           	= 0 ; 0 = no limit
 MaxConstructTriples      	  = 10000000
 ; MaxQueryCostEstimationTime 	= 4000	; in seconds
 ; MaxQueryExecutionTime      	= 1200	; in seconds

--- a/config/virtuoso/virtuoso.ini
+++ b/config/virtuoso/virtuoso.ini
@@ -238,8 +238,8 @@ DefaultHost			= localhost:8890
 ;ImmutableGraphs    		= http://localhost:8890/dataspace
 ResultSetMaxRows           	= 10000000
 MaxConstructTriples      	  = 10000000
-MaxQueryCostEstimationTime 	= 4000	; in seconds
-MaxQueryExecutionTime      	= 1200	; in seconds
+; MaxQueryCostEstimationTime 	= 4000	; in seconds
+; MaxQueryExecutionTime      	= 1200	; in seconds
 DefaultQuery               	= select distinct ?Concept where {[] a ?Concept} LIMIT 100
 DeferInferenceRulesInit    	= 0  ; controls inference rules loading
 MaxMemInUse			= 0  ; limits the amount of memory for construct dict (0=unlimited)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,3 +32,5 @@ services:
     image: lblod/mock-login-service:0.7.0
   migrations:
     restart: "no"
+  lokaal-beslist-consumer:
+    restart: no

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,8 +99,7 @@ services:
       DCR_DISABLE_INITIAL_SYNC: false
       DCR_DISABLE_DELTA_INGEST: true
       BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: true
-      BATCH_SIZE: 1000
-      MAX_DB_RETRY_ATTEMPTS: 5
+      DCR_BATCH_SIZE: 5000
       SLEEP_BETWEEN_BATCHES: 5
     labels:
       - logging=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,11 +95,11 @@ services:
       DCR_INITIAL_SYNC_JOB_OPERATION: http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/decisions-lokaal-beslist
       DCR_DELTA_SYNC_JOB_OPERATION: http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/deltaSync/decisions-ghent
       DCR_JOB_CREATOR_URI: http://data.lblod.info/services/id/decisions-ghent-consumer
-      DCR_ENABLE_DELTA_CONTEXT: true # Mirror copy producer data to landing zone graph
-      DCR_LANDING_ZONE_GRAPH: http://mu.semte.ch/graphs/oslo-decisions/landing
+      INGEST_GRAPH: http://mu.semte.ch/graphs/oslo-decisions/landing
       DCR_DISABLE_INITIAL_SYNC: false
       DCR_DISABLE_DELTA_INGEST: true
       BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: true
+      BATCH_SIZE: 1000
     labels:
       - logging=true
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,8 +96,8 @@ services:
       DCR_DELTA_SYNC_JOB_OPERATION: http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/deltaSync/decisions-ghent
       DCR_JOB_CREATOR_URI: http://data.lblod.info/services/id/decisions-ghent-consumer
       INGEST_GRAPH: http://mu.semte.ch/graphs/oslo-decisions/landing
-      DCR_DISABLE_INITIAL_SYNC: false
-      DCR_DISABLE_DELTA_INGEST: true
+      DCR_DISABLE_INITIAL_SYNC: true # Change in override
+      DCR_DISABLE_DELTA_INGEST: true # Change in override
       BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: true
       DCR_BATCH_SIZE: 5000
       SLEEP_BETWEEN_BATCHES: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,8 @@ services:
       DCR_DISABLE_DELTA_INGEST: true
       BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: true
       BATCH_SIZE: 1000
+      MAX_DB_RETRY_ATTEMPTS: 5
+      SLEEP_BETWEEN_BATCHES: 5
     labels:
       - logging=true
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,3 +85,22 @@ services:
       CREDENTIAL_TYPE: DecideCredential
       NO_DID_PREFIX: true
       SINGLE_CREDENTIAL_RESPONSE: true
+  lokaal-beslist-consumer:
+    image: lblod/delta-consumer:feature-initial-sync-with-virtuoso-dump
+    environment:
+      DCR_SERVICE_NAME: lokaal-beslist-consumer
+      DCR_SYNC_BASE_URL: https://lokaalbeslist-harvester-1.s.redhost.be/ # Harvester 1 hosts Ghent decisions
+      DCR_SYNC_FILES_PATH: /sync/besluiten/files
+      DCR_SYNC_DATASET_SUBJECT: http://data.lblod.info/datasets/delta-producer/dumps/lblod-harvester/BesluitenCacheGraphDump
+      DCR_INITIAL_SYNC_JOB_OPERATION: http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/decisions-lokaal-beslist
+      DCR_DELTA_SYNC_JOB_OPERATION: http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/deltaSync/decisions-ghent
+      DCR_JOB_CREATOR_URI: http://data.lblod.info/services/id/decisions-ghent-consumer
+      DCR_ENABLE_DELTA_CONTEXT: true # Mirror copy producer data to landing zone graph
+      DCR_LANDING_ZONE_GRAPH: http://mu.semte.ch/graphs/oslo-decisions/landing
+      DCR_DISABLE_INITIAL_SYNC: false
+      DCR_DISABLE_DELTA_INGEST: true
+      BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES: true
+    labels:
+      - logging=true
+    restart: always
+    logging: *default-logging


### PR DESCRIPTION
This consumer setup performs an initial sync of the Lokaal Beslist harverst 1 (as it holds decision data coming from Ghent bestuursorganen).
The delta sync step is intentionally disabled as it will be tackled later on. The goal for now is simply to have data available.