### PR TITLE
Transform Ghent decisions to ELI

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,3 +40,5 @@ services:
     restart: no
   decisions-ghent-filter:
     restart: no
+  oslo-eli-transformer:
+    restart: no

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,7 +184,7 @@ services:
   oslo-eli-transformer:
     image: lblod/decide-oslo-to-eli-transformation-service
     environment:
-      BATCH_SIZE: 1000
+      BATCH_SIZE: 100
       SLEEP_BETWEEN_BATCHES: 5
       INPUT_DECISION_RESOURCES_GRAPH: http://mu.semte.ch/graphs/oslo-decisions/ghent/besluit
       INPUT_DATA_GRAPH: http://mu.semte.ch/graphs/oslo-decisions/landing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,3 +181,15 @@ services:
       - logging=true
     restart: always
     logging: *default-logging
+  oslo-eli-transformer:
+    image: lblod/decide-oslo-to-eli-transformation-service
+    environment:
+      BATCH_SIZE: 1000
+      SLEEP_BETWEEN_BATCHES: 5
+      INPUT_DECISION_RESOURCES_GRAPH: http://mu.semte.ch/graphs/oslo-decisions/ghent/besluit
+      INPUT_DATA_GRAPH: http://mu.semte.ch/graphs/oslo-decisions/landing
+      OUTPUT_GRAPH: http://mu.semte.ch/graphs/eli-decisions/ghent
+    labels:
+      - logging=true
+    restart: always
+    logging: *default-logging


### PR DESCRIPTION
> PR for the newly introduced service: https://github.com/lblod/decide-oslo-to-eli-transformation-service/pull/1

After data from Lokaal Beslist has been consumed, and all `besluit:Besluit` resources from Ghent have been filtered and put in their own graph, they should be transformed to ELI resources.

## Try out locally

> The service expects typed `besluit:Besluit` resources in the `http://mu.semte.ch/graphs/oslo-decisions/ghent/besluit` graph and all other `besluit:Besluit` data in the `http://mu.semte.ch/graphs/oslo-decisions/landing` graph. Instead of providing all this data yourself, you can review the output of this service on the Decide server (see further below for instructions).

To try out the service locally, add this to `docker-compose.override.yml`:

```yml
services:
  oslo-eli-transformer:
    image: lblod/decide-oslo-to-eli-transformation-service:feature-transform-besluit-batch
    ports:
      - "8888:80"
```

Start the transformation of `besluit:Besluit` data by calling the correct endpoint:

```bash
curl -X POST http://localhost:8888/transform
```

## Review on server

The steps above have already been executed on the Decide server, so you can review the resulting data over there:

```bash
cd /data/ingest-lokaal-beslist/
```

```bash
drc exec -it virtuoso isql-v
```

```bash
sparql SELECT DISTINCT ?type WHERE { GRAPH <http://mu.semte.ch/graphs/eli-decisions/ghent> { ?s a ?type } };
```