### PR TITLE
feat: add support DSP Catalog protocol

### DIFF
--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -45,7 +45,7 @@
   :tasks "http://redpencil.data.gift/vocabularies/tasks/"
   :wot "https://www.w3.org/2019/wot/security#"
   :defend "https://d3fend.mitre.org/ontologies/d3fend#"
-)
+  :odrl "http://www.w3.org/ns/odrl/2/")
 
 (define-graph harvesting ("http://mu.semte.ch/graphs/harvesting")
   ("tasks:Task" -> _ )
@@ -75,6 +75,7 @@
   ("nfo:RemoteDataObject" -> _)
   ("nfo:FileDataObject" -> _))
 
+;; TODO: Add ODRL Offer resources
 (define-graph public ("http://mu.semte.ch/graphs/public")
   ("besluit:Bestuurseenheid" -> _)
   ("cms:Page" -> _)
@@ -105,7 +106,12 @@
   ("org:Organization" -> _)
   ("skos:Concept" -> _)
   ("skos:ConceptScheme" -> _)
-)
+  ;; Data for ODRL Offers used in DSP
+  ("odrl:Offer" -> _)
+  ("odrl:Duty" -> _)
+  ("odrl:Permission" -> _)
+  ("odrl:Prohibition" -> _)
+  ("odrl:Constraint"))
 
 (supply-allowed-group "public")
 

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -10,7 +10,7 @@ defmodule Dispatcher do
 
   define_layers([:static, :sparql, :api_services, :frontend_fallback, :resources, :not_found])
 
-  options "/*path", _ do
+  options "/*_path", _ do
     conn
     |> Plug.Conn.put_resp_header("access-control-allow-headers", "content-type,accept")
     |> Plug.Conn.put_resp_header("access-control-allow-methods", "*")
@@ -295,12 +295,12 @@ defmodule Dispatcher do
   #################
 
   # self-service
-  match "/*path", %{reverse_host: ["dashboard" | _rest], accept: %{html: true}} do
+  match "/*_path", %{reverse_host: ["dashboard" | _rest], accept: %{html: true}} do
     # we don't forward the path, because the app should take care of this in the browser.
     forward(conn, [], "http://frontend-harvesting/index.html")
   end
 
-  match "/*path", %{layer: :frontend_fallback, accept: %{html: true}} do
+  match "/*_path", %{layer: :frontend_fallback, accept: %{html: true}} do
     # we don't forward the path, because the app should take care of this in the browser.
     forward(conn, [], "http://frontend/index.html")
   end

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -103,6 +103,14 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://resource/remote-data-objects/"
   end
 
+  #################
+  # DSP
+  #################
+
+  # Catalog protocol
+  match "/dsp/2025-1/catalog/*path", %{ accept: [:json], layer: :api_services} do
+    Proxy.forward conn, path, "http://dcat/dsp/2025-1/catalog/"
+  end
 
   #################
   # OPARL PROXY

--- a/config/migrations/20251126110231-dsp--example-odrl-offers/20251126110231-example-odrl-offer-dataset.graph
+++ b/config/migrations/20251126110231-dsp--example-odrl-offers/20251126110231-example-odrl-offer-dataset.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20251126110231-dsp--example-odrl-offers/20251126110231-example-odrl-offer-dataset.ttl
+++ b/config/migrations/20251126110231-dsp--example-odrl-offers/20251126110231-example-odrl-offer-dataset.ttl
@@ -1,0 +1,50 @@
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+ext:exampleOffer a odrl:Offer ;
+  # The `target` and `assigner` will be shared for all contained rules, see
+  # <https://www.w3.org/TR/odrl-model/#composition-compact>
+  odrl:target <http://data.lblod.info/id/datasets/123e4567-e89b-12d3-a456-426614174000> ;
+  odrl:assigner ext:decideParty ;
+  # Rules
+  odrl:permission ext:readPermission ;
+  odrl:permission ext:distributePermission ;
+  odrl:duty ext:attributeDuty ;
+  odrl:prohibition ext:sellProhibition .
+
+ext:readPermission a odrl:Permission ;
+  odrl:action odrl:read .
+
+ext:distributePermission a odrl:Permission ;
+  odrl:action odrl:distribute ;
+  odrl:constraint ext:afterDateConstraint ;
+  odrl:constraint ext:exampleConstraint .
+
+ext:afterDateConstraint a odrl:Constraint ;
+  odrl:leftOperand "dateTime" ;
+  odrl:operator "gt" ;
+  odrl:rightOperand "2026-09-01"^^xsd:date .
+
+ext:exampleConstraint a odrl:Constraint ;
+  odrl:leftOperand 1 ;
+  odrl:operator "eq" ;
+  odrl:rightOperand 1 .
+
+ext:sellProhibition a odrl:Prohibition ;
+  # Definition of `odrl:sell`: "To transfer the ownership of the Asset to a
+  # third party with compensation and while deleting the original asset."
+  # <https://www.w3.org/TR/odrl-vocab/#term-sell>
+  odrl:action odrl:sell .
+
+# Example Duty to illustrate how we could use that to require that DECIDe is
+# attributed for the shared dataset.
+ext:attributeDuty a odrl:Duty ;
+  odrl:action odrl:attribute ;
+  odrl:attributedParty ext:decideParty .
+
+ext:decideParty a odrl:Party ;
+  vcard:fn "DECIDe application" ;
+  vcard:hasEmail "decide@lblod.info" ; # Fictitious email for example purposes
+  vcard:hasURL "https://ds.decide.lblod.info" . # Fictitious url for example purposes

--- a/config/migrations/20251126110231-dsp--example-odrl-offers/20251126110231-example-odrl-offer-dataset.ttl
+++ b/config/migrations/20251126110231-dsp--example-odrl-offers/20251126110231-example-odrl-offer-dataset.ttl
@@ -46,5 +46,5 @@ ext:attributeDuty a odrl:Duty ;
 
 ext:decideParty a odrl:Party ;
   vcard:fn "DECIDe application" ;
-  vcard:hasEmail "decide@lblod.info" ; # Fictitious email for example purposes
-  vcard:hasURL "https://ds.decide.lblod.info" . # Fictitious url for example purposes
+  vcard:hasEmail "email@example.com" ; # Fictitious email for example purposes
+  vcard:hasURL "https://www.example.com" . # Fictitious url for example purposes

--- a/config/migrations/20251126110231-dsp--example-odrl-offers/20251129111308-example-catalog-data.graph
+++ b/config/migrations/20251126110231-dsp--example-odrl-offers/20251129111308-example-catalog-data.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20251126110231-dsp--example-odrl-offers/20251129111308-example-catalog-data.ttl
+++ b/config/migrations/20251126110231-dsp--example-odrl-offers/20251129111308-example-catalog-data.ttl
@@ -1,0 +1,15 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+
+# Catalog added in 20251013113800-add-test-dcat-catalog-data migration
+<http://data.lblod.info/id/catalogs/5d39120a-9575-41aa-b098-a63d6df99e6b> dcat:distribution ext:exampleDistributionForCatalog ;
+  dcat:catalog ext:exampleContainedCatalog .
+
+ext:exampleDistributionForCatalog a dcat:Distribution ;
+  dcterms:title "Example distribution";
+  dcat:accessURL <https://example.org/access> ;
+  dcterms:format <http://data.lblod.info/id/formats/a6a5b899-35f3-4194-aad7-9e35448bf43d> .
+
+ext:exampleContainedCatalog a dcat:Catalog ;
+  dcterms:title "A contained catalog" .

--- a/config/migrations/20251126110231-dsp--example-odrl-offers/20251130111701-insert-contained-catalog.graph
+++ b/config/migrations/20251126110231-dsp--example-odrl-offers/20251130111701-insert-contained-catalog.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20251126110231-dsp--example-odrl-offers/20251130111701-insert-contained-catalog.ttl
+++ b/config/migrations/20251126110231-dsp--example-odrl-offers/20251130111701-insert-contained-catalog.ttl
@@ -1,0 +1,23 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+
+# Initial resource was added in 20251129111308-example-catalog-data.ttl
+ext:exampleContainedCatalog dcat:distribution ext:exampleDistributionForContainedCatalog ;
+  dcat:dataset ext:exampleDatasetForContainedCatalog .
+
+ext:exampleDistributionForContainedCatalog a dcat:Distribution ;
+  dcterms:title "Example distribution";
+  dcat:accessURL <https://example.org/access> ;
+  dcterms:format <http://data.lblod.info/id/formats/a6a5b899-35f3-4194-aad7-9e35448bf43d> .
+
+ext:exampleDatasetForContainedCatalog a dcat:Dataset;
+  dcterms:title "Example Dataset for a contained catalog"@en ;
+  odrl:hasPolicy ext:exampleOffer ;
+  dcat:distribution ext:exampleDistributionForDataset .
+
+ext:exampleDistributionForDataset a dcat:Distribution;
+  dcterms:title "Foo distribution" ;
+  dcat:accessURL <https://example.org/access> ;
+  dcterms:format <http://data.lblod.info/id/formats/a6a5b899-35f3-4194-aad7-9e35448bf43d> .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,6 +21,8 @@ services:
     restart: "no"
   virtuoso:
     restart: "no"
+    ports:
+      - "8890:8890"
     networks:
       - default
       - debug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
     restart: "no"
   dcat:
     image: lblod/dcat-service:0.0.1
+    environment:
+      BASE_URL: "https://ds.decide.lblod.info/"
   odrl-parser:
     image: lblod/odrl-parser-service:0.0.3
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,8 @@ services:
     image: lblod/dcat-service:0.0.1
     environment:
       BASE_URL: "https://ds.decide.lblod.info/"
+      DSP_SERVICE_ID: "urn:example:6e2e3fcb-8a66-4d81-a4cd-ba2eea954396"
+      DSP_PARTICIPANT_ID: "urn:example:DecideDataProvider"
   odrl-parser:
     image: lblod/odrl-parser-service:0.0.3
     volumes:


### PR DESCRIPTION
Extend the application to support the DSP Catalog protocol implemented by the DCAT-service in [#2](https://github.com/lblod/dcat-service/pull/2). This PR adds a route for the service's new functionality, and configures the appropriate environment variables for the service. Note that the set `BASE_URL` is an example, and might change in the future.

Furthermore, this PR adds some migrations with additional example data to better illustrate the service's DSP Catalog protocol functionality. This data is for example/testing purposes only, and should **not** be merged into the application.

## Notes
This PR also introduces two small unrelated changes:
- Silence warnings by the dispatcher about unused `path` variables by prefixing them with a `_`. This makes the dispatcher output a little bit cleaner.
- In a DEV setup, expose port 8890 of the `virtuoso` service. This makes it a  it easier to directly query the triplestore during development.

## Related PRs
- [DCAT service](https://github.com/lblod/dcat-service/pull/2) extension for DSP Catalog Protocol

## Related tickets
- LBRON-784