### PR TITLE
Add real DCAT datasets, distributions and services

### DIFF
--- a/config/migrations/add-decide-datasets/20260108152100-overview.graph
+++ b/config/migrations/add-decide-datasets/20260108152100-overview.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/add-decide-datasets/20260108152100-overview.ttl
+++ b/config/migrations/add-decide-datasets/20260108152100-overview.ttl
@@ -30,27 +30,24 @@ agent:7365f73a-b57c-4999-aa8b-61464d9d3c6f a foaf:Agent;
 .
 
 agent:658900ce-63cf-4d45-8fd5-a67ed8deab2c a foaf:Agent;
-    vcard:hasName "Municipality of Freiburg"@en
-.
-
-agent:c3c2a7bf-af3b-43b8-99f5-c3463ec9408a a foaf:Agent;
-    vcard:hasName "Vlaamse Overheid"@nl, "Flemish government"@en
+    vcard:hasName "Municipality of Freiburg"@en;
+    vcard:hasEmail "rsk-ratsbuero@freiburg.de"
 .
 
 agent:f45c1220-b250-4b93-8a8a-3e7e4a12a467 a foaf:Agent;
-    vcard:hasName "ABB Open Proces Huis"@nl
-.
-
-agent:436c5bce-8380-401e-8027-f34ef4acd97e a foaf:Agent;
-    vcard:hasName "ABB Lokaal Beslist"@nl
+    vcard:hasName "Agentschap Binnenlands Bestuur"@nl;
+    vcard:hasEmail "binnenland@vlaanderen.be"
 .
 
 agent:7cb46783-0ca2-41a2-b28c-248b99e752e4 a foaf:Agent;
-    vcard:hasName "ABB DECIDe"@nl
+    vcard:hasName "Agentschap Binnenlands Bestuur (DECIDe)"@nl;
+    vcard:hasEmail "binnenland@vlaanderen.be";
+    rdfs:comment "This is for datasets published within the DECIDe project; the actual entity and contact data may be subject to change."@en
 .
 
-agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb a foaf:Agent;
-    vcard:hasName "ABB DECIDe AI Team"@nl
+agent:436c5bce-8380-401e-8027-f34ef4acd97e a foaf:Agent;
+    vcard:hasName "Lokaal Beslist"@nl;
+    vcard:hasEmail "lokaalbeslist@vlaanderen.be"
 .
 
 agent:945e9df0-c9e6-4f5c-a249-34075169e68d a foaf:Agent;
@@ -218,8 +215,8 @@ dataset:dd91b174-e9bb-4d33-8732-ed064a828b60 a dcat:Dataset;
     mu:uuid "dd91b174-e9bb-4d33-8732-ed064a828b60";
     dct:title "Ghent Municipal Decisions Roadblocks Classification"@en;
     dct:description "A comprehensive dataset of Dutch municipal decision documents from Ghent, Belgium, specifically processed and classified for traffic measures, roadblocks, and infrastructure projects that affect urban mobility."@en;
-    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
+    dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/REGI>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:distribution distribution:f27a58aa-5cbf-4612-b3d0-a4d49100153f
@@ -237,8 +234,8 @@ dataset:2e1d52d9-2509-4b60-ac5a-0307897d64ef a dcat:Dataset;
     mu:uuid "2e1d52d9-2509-4b60-ac5a-0307897d64ef";
     dct:title "llama3 ABB Instruct"@en;
     dct:description "A comprehensive dataset to fine tune a llama3 model for translation, classification and keyword extraction from decision documents from Ghent"@en;
-    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
+    dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:distribution distribution:4ed47dd1-aa35-4f94-b751-c0984349908c
@@ -256,8 +253,8 @@ dataset:6aaa542d-410c-4150-bcfd-e5526eab87f4 a dcat:Dataset;
     mu:uuid "6aaa542d-410c-4150-bcfd-e5526eab87f4";
     dct:title "ABB DECIDe SDGs Antwerp"@en;
     dct:description "A comprehensive dataset to classify decision documents from Antwerp into Sustainable Development Goals"@en;
-    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
+    dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/ENVI>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:distribution distribution:6d5607a1-e1b3-4259-b186-760d8fef7da3
@@ -275,8 +272,8 @@ dataset:3d79b143-4009-451a-8b80-423da944d9a8 a dcat:Dataset;
     mu:uuid "3d79b143-4009-451a-8b80-423da944d9a8";
     dct:title "ABB DECIDe title extraction instruct"@en;
     dct:description "A comprehensive dataset to identify and extract the title from plain text decision documents from Ghent with the help of llama3"@en;
-    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
+    dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:distribution distribution:b8b63c96-f5ce-496a-937e-7406f6aa1b91
@@ -294,8 +291,8 @@ dataset:6b65a734-7d22-4486-97e3-c7eafc7341d5 a dcat:Dataset;
     mu:uuid "6b65a734-7d22-4486-97e3-c7eafc7341d5";
     dct:title "Flanders NER and Segmentation dataset"@en;
     dct:description "Labelstudio data to train segmentation and NER models on decision data from Flemish cities"@en;
-    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
+    dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:distribution distribution:a9233283-4233-41b0-a4e4-ab470c49a6f6
@@ -313,8 +310,8 @@ dataset:38fd6817-f185-478d-9e21-12d6a694834c a dcat:Dataset;
     mu:uuid "38fd6817-f185-478d-9e21-12d6a694834c";
     dct:title "Freiburg NER and Segmentation dataset"@en;
     dct:description "A comprehensive dataset to train segmentation and NER models on decision data from Freiburg"@en;
-    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
+    dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:distribution distribution:66b310c8-4d2b-4f8f-a292-c1882f939e6c
@@ -332,8 +329,8 @@ dataset:2ba4d174-e492-4bf2-b3a6-425f7afa51bf a dcat:Dataset;
     mu:uuid "2ba4d174-e492-4bf2-b3a6-425f7afa51bf";
     dct:title "Bamberg NER and Segmentation dataset"@en;
     dct:description "A comprehensive dataset to train segmentation and NER models on decision data from Bamberg"@en;
-    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
+    dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:distribution distribution:7125af8b-f298-44a5-9c5f-c3db1b296fbd
@@ -351,8 +348,8 @@ dataset:b0d10410-8bd0-408d-81d1-5794296e3e1b a dcat:Dataset;
     mu:uuid "dataset:b0d10410-8bd0-408d-81d1-5794296e3e1b";
     dct:title "Combined translated dataset"@en;
     dct:description "A comprehensive dataset to train segmentation and NER models on decision data from Bamberg, Freiburg and Ghent in English"@en;
-    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
+    dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:distribution distribution:ab53349d-155c-4ed4-ad5a-27404488b69b
@@ -487,8 +484,8 @@ dataset:3840171f-daf5-4efe-bf42-e7d511e6a1c1 a dcat:Dataset;
     mu:uuid "3840171f-daf5-4efe-bf42-e7d511e6a1c1";
     dct:title "Freiburg local decisions"@en;
     dct:description "The data for Freiburg is retrieved from the city's public meeting API (https://ris.freiburg.de/oparl/). It first requests page 1 to determine the total number of meeting pages, then iterates through all pages to collect agenda items from each meeting. For each agenda item with a resolutionFile, it downloads the file, verifies that the content is a real PDF, and saves it locally with a unique filename. "@en;
-    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
+    dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     rdfs:seeAlso "https://app.gitbook.com/o/-MP9Yduzf5xu7wIebqPG/s/grRYjcouX0uZY2P6PYBl/ai-analysis-research/ai-approach-uc-0.0/named-entity-recognition"^^xsd:anyURI;
@@ -506,8 +503,8 @@ dataset:8a84f8a5-613a-45d0-bd43-e430dd3516ce a dcat:Dataset;
     mu:uuid "8a84f8a5-613a-45d0-bd43-e430dd3516ce";
     dct:title "Bamberg local decisions"@en;
     dct:description "The Bamberg data is scraped from the city's decision consultation website (https://www.stadt.bamberg.de/buergerinformationssystem/) by iterating through a large range of possible volfdnrs. Multiple workers run in parallel to probe each volfdnr, extract structured page content when a valid record exists, and write results to JSONL files. After scraping, all worker outputs are merged into a single deduplicated dataset. For entries that include a “Vorlage” PDF, the script must first open the item’s resolutionUrl to obtain a valid session cookie, because the PDF links provided by the Bamberg Bürgerinformationssystem are Wicket resource URLs that only work with an active session. "@en;
-    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
+    dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:distribution distribution:7661627c-3cae-4991-bbdc-1f0a3f633781

--- a/config/migrations/add-decide-datasets/20260108152100-overview.ttl
+++ b/config/migrations/add-decide-datasets/20260108152100-overview.ttl
@@ -63,19 +63,19 @@ agent:945e9df0-c9e6-4f5c-a249-34075169e68d a foaf:Agent;
 
 dataset:2bb49e25-feb1-4daf-b98a-6c274e7d6d7d a dcat:Dataset;
     mu:uuid "2bb49e25-feb1-4daf-b98a-6c274e7d6d7d";
-    dct:title "Lokaal Beslist Harvester 0";
-    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dct:title "Lokaal Beslist Harvester 0"@nl;
+    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
     dct:publisher agent:;
     dcat:contactPoint agent:436c5bce-8380-401e-8027-f34ef4acd97e;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:distribution distribution:4697a3e9-9225-4ca1-a17c-0df585b4f872
 .
 distribution:4697a3e9-9225-4ca1-a17c-0df585b4f872 a dcat:Distribution;
     mu:uuid "4697a3e9-9225-4ca1-a17c-0df585b4f872";
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
-    dct:title "Lokaal Beslist SPARQL Endpoint 0";
-    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten";
+    dct:title "Lokaal Beslist SPARQL Endpoint 0"@nl;
+    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten"@nl;
     dcat:accessURL "https://lokaalbeslist-harvester-0.s.redhost.be/sparql"^^xsd:anyURI;
     dcat:accessService service:df87f118-165c-468d-b558-99f5c324d334;
     dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
@@ -83,85 +83,97 @@ distribution:4697a3e9-9225-4ca1-a17c-0df585b4f872 a dcat:Distribution;
 service:df87f118-165c-468d-b558-99f5c324d334 a dcat:DataService ;
     mu:uuid "df87f118-165c-468d-b558-99f5c324d334";
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
+    dct:title "Lokaal Beslist SPARQL Endpoint 0"@nl;
+    dcat:endpointDescription "Endpoint met lokale besluiten van Vlaamse gemeenten"@nl;
     dcat:endpointURL "https://lokaalbeslist-harvester-0.s.redhost.be/sparql"^^xsd:anyURI ;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:2bb49e25-feb1-4daf-b98a-6c274e7d6d7d
 .
 
 dataset:cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6 a dcat:Dataset;
     mu:uuid "cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6";
-    dct:title "Lokaal Beslist Harvester 1";
-    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dct:title "Lokaal Beslist Harvester 1"@nl;
+    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
     dct:publisher agent:436c5bce-8380-401e-8027-f34ef4acd97e;
     dcat:contactPoint agent:436c5bce-8380-401e-8027-f34ef4acd97e;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:distribution distribution:3e9974a1-2182-404b-b60a-84a64468df31
 .
 distribution:3e9974a1-2182-404b-b60a-84a64468df31 a dcat:Distribution;
     mu:uuid "3e9974a1-2182-404b-b60a-84a64468df31";
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
-    dct:title "Lokaal Beslist SPARQL Endpoint 1";
-    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dct:title "Lokaal Beslist SPARQL Endpoint 1"@nl;
+    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
     dcat:accessURL "https://lokaalbeslist-harvester-1.s.redhost.be/sparql"^^xsd:anyURI;
     dcat:accessService service:57638b91-d88b-44cb-9664-61d108bb92e7;
     dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
 .
 service:57638b91-d88b-44cb-9664-61d108bb92e7 a dcat:DataService ;
     mu:uuid "57638b91-d88b-44cb-9664-61d108bb92e7";
+    dct:title "Lokaal Beslist Harvester 1"@nl;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
+    dcat:endpointDescription "Endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
     dcat:endpointURL "https://lokaalbeslist-harvester-1.s.redhost.be/sparql"^^xsd:anyURI ;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6
 .
 
 dataset:0b2ad45a-eccf-45ac-874d-8b498a172772 a dcat:Dataset;
     mu:uuid "0b2ad45a-eccf-45ac-874d-8b498a172772";
-    dct:title "Lokaal Beslist Harvester 2";
-    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dct:title "Lokaal Beslist Harvester 2"@nl;
+    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
     dct:publisher agent:436c5bce-8380-401e-8027-f34ef4acd97e;
     dcat:contactPoint agent:436c5bce-8380-401e-8027-f34ef4acd97e;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:distribution distribution:e5f475b5-c6d3-4ff2-b8fc-0a81003138a0
 .
 distribution:e5f475b5-c6d3-4ff2-b8fc-0a81003138a0 a dcat:Distribution;
     mu:uuid "e5f475b5-c6d3-4ff2-b8fc-0a81003138a0";
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
-    dct:title "Lokaal Beslist SPARQL Endpoint 2";
-    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dct:title "Lokaal Beslist SPARQL Endpoint 2"@nl;
+    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
     dcat:accessURL "https://lokaalbeslist-harvester-2.s.redhost.be/sparql"^^xsd:anyURI;
     dcat:accessService service:706a5fda-ef6e-496e-a312-15a0620efe12;
     dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
 .
 service:706a5fda-ef6e-496e-a312-15a0620efe12 a dcat:DataService ;
     mu:uuid "706a5fda-ef6e-496e-a312-15a0620efe12";
+    dct:title "Lokaal Beslist Harvester 2"@nl;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
+    dcat:endpointDescription "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
     dcat:endpointURL "https://lokaalbeslist-harvester-2.s.redhost.be/sparql"^^xsd:anyURI ;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:0b2ad45a-eccf-45ac-874d-8b498a172772
 .
 
 dataset:f7a4bbb3-1fef-4975-9049-ee933cfce30e a dcat:Dataset;
     mu:uuid "f7a4bbb3-1fef-4975-9049-ee933cfce30e";
-    dct:title "Lokaal Beslist Harvester 3";
-    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dct:title "Lokaal Beslist Harvester 3"@nl;
+    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
     dct:publisher agent:436c5bce-8380-401e-8027-f34ef4acd97e;
     dcat:contactPoint agent:436c5bce-8380-401e-8027-f34ef4acd97e;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:distribution distribution:19bada3c-fc39-4524-a692-d45e735f578f
 .
 distribution:19bada3c-fc39-4524-a692-d45e735f578f a dcat:Distribution;
     mu:uuid "19bada3c-fc39-4524-a692-d45e735f578f";
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
-    dct:title "Lokaal Beslist SPARQL Endpoint 3";
-    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dct:title "Lokaal Beslist SPARQL Endpoint 3"@nl;
+    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
     dcat:accessURL "https://lokaalbeslist-harvester-3.s.redhost.be/sparql"^^xsd:anyURI;
     dcat:accessService service:ec5feb51-9108-4c35-adef-d799f64bab9d;
     dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
 .
 service:ec5feb51-9108-4c35-adef-d799f64bab9d a dcat:DataService ;
     mu:uuid "ec5feb51-9108-4c35-adef-d799f64bab9d";
+    dct:title "Lokaal Beslist SPARQL Endpoint 3"@nl;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
+    dcat:endpointDescription "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
     dcat:endpointURL "https://lokaalbeslist-harvester-3.s.redhost.be/sparql"^^xsd:anyURI ;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:f7a4bbb3-1fef-4975-9049-ee933cfce30e
 .
 
@@ -170,24 +182,27 @@ service:ec5feb51-9108-4c35-adef-d799f64bab9d a dcat:DataService ;
 
 dataset:74c12f17-f0eb-4bf2-8390-0d21655f00e3 a dcat:Dataset;
     mu:uuid "74c12f17-f0eb-4bf2-8390-0d21655f00e3";
-    dct:title "Open Proces Huis procesdata";
-    dct:description "Proces-, diagram- en invatarisdata van Open Proces Huis";
+    dct:title "Open Proces Huis procesdata"@nl;
+    dct:description "Proces-, diagram- en invatarisdata van Open Proces Huis"@nl;
     dct:publisher agent:f45c1220-b250-4b93-8a8a-3e7e4a12a467;
     dcat:contactPoint agent:945e9df0-c9e6-4f5c-a249-34075169e68d;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dct:distribution distribution:ad94e41e-a790-44bc-8602-e1fe0c7bc1b0
 .
 distribution:ad94e41e-a790-44bc-8602-e1fe0c7bc1b0 a dcat:Distribution;
     mu:uuid "ad94e41e-a790-44bc-8602-e1fe0c7bc1b0";
-    dct:title "SPARQL endpoint";
-    dcat:accessURL "https://openproceshuis.vlaanderen.be/sparql";
+    dct:title "SPARQL endpoint"@nl;
+    dcat:accessURL "https://openproceshuis.vlaanderen.be/sparql"^^xsd:anyURI;
     dcat:accessService service:7333d62b-bd34-4063-ad34-28ec22a098b5
 .
 service:7333d62b-bd34-4063-ad34-28ec22a098b5 a dcat:DataService ;
     mu:uuid "7333d62b-bd34-4063-ad34-28ec22a098b5";
+    dct:title "Open Proces Huis procesdata"@nl;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
+    dcat:endpointDescription "Proces-, diagram- en invatarisdata van Open Proces Huis"@nl;
     dcat:endpointURL "https://openproceshuis.vlaanderen.be/sparql"^^xsd:anyURI ;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:74c12f17-f0eb-4bf2-8390-0d21655f00e3
 .
 
@@ -196,11 +211,11 @@ service:7333d62b-bd34-4063-ad34-28ec22a098b5 a dcat:DataService ;
 
 dataset:dd91b174-e9bb-4d33-8732-ed064a828b60 a dcat:Dataset;
     mu:uuid "dd91b174-e9bb-4d33-8732-ed064a828b60";
-    dct:title "Ghent Municipal Decisions Roadblocks Classification";
-    dct:description "A comprehensive dataset of Dutch municipal decision documents from Ghent, Belgium, specifically processed and classified for traffic measures, roadblocks, and infrastructure projects that affect urban mobility.";
+    dct:title "Ghent Municipal Decisions Roadblocks Classification"@en;
+    dct:description "A comprehensive dataset of Dutch municipal decision documents from Ghent, Belgium, specifically processed and classified for traffic measures, roadblocks, and infrastructure projects that affect urban mobility."@en;
     dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
     dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/REGI>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/REGI>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:distribution distribution:f27a58aa-5cbf-4612-b3d0-a4d49100153f
 .
@@ -208,18 +223,18 @@ distribution:f27a58aa-5cbf-4612-b3d0-a4d49100153f a dcat:Distribution;
     mu:uuid "f27a58aa-5cbf-4612-b3d0-a4d49100153f";
     rdfs:comment "HuggingFace";
     dct:format <http://publications.europa.eu/resource/authority/file-type/PARQUET>;
-    dct:title "Ghent Municipal Decisions Roadblocks Classification";
-    dct:description "HuggingFace data of Dutch municipal decision documents from Ghent, Belgium, specifically processed and classified for traffic measures, roadblocks, and infrastructure projects that affect urban mobility.";
+    dct:title "Ghent Municipal Decisions Roadblocks Classification"@en;
+    dct:description "HuggingFace data of Dutch municipal decision documents from Ghent, Belgium, specifically processed and classified for traffic measures, roadblocks, and infrastructure projects that affect urban mobility."@en;
     dcat:accessURL "https://huggingface.co/datasets/svercoutere/abb-decide-ghent-roadblocks-classification"^^xsd:anyURI
 .
 
 dataset:2e1d52d9-2509-4b60-ac5a-0307897d64ef a dcat:Dataset;
     mu:uuid "2e1d52d9-2509-4b60-ac5a-0307897d64ef";
-    dct:title "llama3 ABB Instruct";
-    dct:description "A comprehensive dataset to fine tune a llama3 model for translation, classification and keyword extraction from decision documents from Ghent";
+    dct:title "llama3 ABB Instruct"@en;
+    dct:description "A comprehensive dataset to fine tune a llama3 model for translation, classification and keyword extraction from decision documents from Ghent"@en;
     dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
     dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:distribution distribution:4ed47dd1-aa35-4f94-b751-c0984349908c
 .
@@ -227,18 +242,18 @@ distribution:4ed47dd1-aa35-4f94-b751-c0984349908c a dcat:Distribution;
     mu:uuid "4ed47dd1-aa35-4f94-b751-c0984349908c";
     rdfs:comment "HuggingFace";
     dct:format <http://publications.europa.eu/resource/authority/file-type/PARQUET>;
-    dct:title "llama3 ABB Instruct";
-    dct:description "HuggingFace data to fine tune a llama3 model for translation, classification and keyword extraction from decision documents from Ghent";
+    dct:title "llama3 ABB Instruct"@en;
+    dct:description "HuggingFace data to fine tune a llama3 model for translation, classification and keyword extraction from decision documents from Ghent"@en;
     dcat:accessURL "https://huggingface.co/datasets/svercoutere/llama3_abb_instruct_dataset"^^xsd:anyURI
 .
 
 dataset:6aaa542d-410c-4150-bcfd-e5526eab87f4 a dcat:Dataset;
     mu:uuid "6aaa542d-410c-4150-bcfd-e5526eab87f4";
-    dct:title "ABB DECIDe SDGs Antwerp";
-    dct:description "A comprehensive dataset to classify decision documents from Antwerp into Sustainable Development Goals";
+    dct:title "ABB DECIDe SDGs Antwerp"@en;
+    dct:description "A comprehensive dataset to classify decision documents from Antwerp into Sustainable Development Goals"@en;
     dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
     dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/ENVI>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/ENVI>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:distribution distribution:6d5607a1-e1b3-4259-b186-760d8fef7da3
 .
@@ -246,18 +261,18 @@ distribution:6d5607a1-e1b3-4259-b186-760d8fef7da3 a dcat:Distribution;
     mu:uuid "6d5607a1-e1b3-4259-b186-760d8fef7da3";
     rdfs:comment "HuggingFace";
     dct:format <http://publications.europa.eu/resource/authority/file-type/PARQUET>;
-    dct:title "ABB DECIDe SDGs Antwerp";
-    dct:description "HuggingFace data to classify decision documents from Antwerp into Sustainable Development Goals";
+    dct:title "ABB DECIDe SDGs Antwerp"@en;
+    dct:description "HuggingFace data to classify decision documents from Antwerp into Sustainable Development Goals"@en;
     dcat:accessURL "https://huggingface.co/datasets/svercoutere/abb-decide-sdgs-antwerp"^^xsd:anyURI
 .
 
-dataset:3d79b143-4009-451a-8b80-423da944d9a8 a dcat:Distribution;
+dataset:3d79b143-4009-451a-8b80-423da944d9a8 a dcat:Dataset;
     mu:uuid "3d79b143-4009-451a-8b80-423da944d9a8";
-    dct:title "ABB DECIDe title extraction instruct";
-    dct:description "A comprehensive dataset to identify and extract the title from plain text decision documents from Ghent with the help of llama3";
+    dct:title "ABB DECIDe title extraction instruct"@en;
+    dct:description "A comprehensive dataset to identify and extract the title from plain text decision documents from Ghent with the help of llama3"@en;
     dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
     dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:distribution distribution:b8b63c96-f5ce-496a-937e-7406f6aa1b91
 .
@@ -265,18 +280,18 @@ distribution:b8b63c96-f5ce-496a-937e-7406f6aa1b91 a dcat:Distribution;
     mu:uuid "b8b63c96-f5ce-496a-937e-7406f6aa1b91";
     rdfs:comment "HuggingFace";
     dct:format <http://publications.europa.eu/resource/authority/file-type/PARQUET>;
-    dct:title "ABB DECIDe title extraction instruct";
-    dct:description "HuggingFace data to identify and extract the title from plain text decision documents from Ghent with the help of llama3";
+    dct:title "ABB DECIDe title extraction instruct"@en;
+    dct:description "HuggingFace data to identify and extract the title from plain text decision documents from Ghent with the help of llama3"@en;
     dcat:accessURL "https://huggingface.co/datasets/PedroDKE/ABB-DECIDe-title-extraction-instruct-dataset"^^xsd:anyURI
 .
 
 dataset:6b65a734-7d22-4486-97e3-c7eafc7341d5 a dcat:Dataset;
     mu:uuid "6b65a734-7d22-4486-97e3-c7eafc7341d5";
-    dct:title "Flanders NER and Segmentation dataset";
-    dct:description "Labelstudio data to train segmentation and NER models on decision data from Flemish cities";
+    dct:title "Flanders NER and Segmentation dataset"@en;
+    dct:description "Labelstudio data to train segmentation and NER models on decision data from Flemish cities"@en;
     dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
     dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:distribution distribution:a9233283-4233-41b0-a4e4-ab470c49a6f6
 .
@@ -284,18 +299,18 @@ distribution:a9233283-4233-41b0-a4e4-ab470c49a6f6 a dcat:Distribution;
     mu:uuid "a9233283-4233-41b0-a4e4-ab470c49a6f6";
     rdfs:comment "Labelstudio";
     dct:format <http://publications.europa.eu/resource/authority/file-type/OCTET>;
-    dct:title "Flanders NER and Segmentation dataset";
-    dct:description "Labelstudio data to train segmentation and NER models on decision data from Flemish cities";
+    dct:title "Flanders NER and Segmentation dataset"@en;
+    dct:description "Labelstudio data to train segmentation and NER models on decision data from Flemish cities"@en;
     dcat:accessURL "https://labelstudio.abb.ml2grow.cloud/projects/25/data?tab=73"^^xsd:anyURI
 .
 
 dataset:38fd6817-f185-478d-9e21-12d6a694834c a dcat:Dataset;
     mu:uuid "38fd6817-f185-478d-9e21-12d6a694834c";
-    dct:title "Freiburg NER and Segmentation dataset";
-    dct:description "A comprehensive dataset to train segmentation and NER models on decision data from Freiburg";
+    dct:title "Freiburg NER and Segmentation dataset"@en;
+    dct:description "A comprehensive dataset to train segmentation and NER models on decision data from Freiburg"@en;
     dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
     dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:distribution distribution:66b310c8-4d2b-4f8f-a292-c1882f939e6c
 .
@@ -303,18 +318,18 @@ distribution:66b310c8-4d2b-4f8f-a292-c1882f939e6c a dcat:Distribution;
     mu:uuid "66b310c8-4d2b-4f8f-a292-c1882f939e6c";
     rdfs:comment "Labelstudio";
     dct:format <http://publications.europa.eu/resource/authority/file-type/OCTET>;
-    dct:title "Freiburg NER and Segmentation dataset";
-    dct:description "Labelstudio data to train segmentation and NER models on decision data from Freiburg";
+    dct:title "Freiburg NER and Segmentation dataset"@en;
+    dct:description "Labelstudio data to train segmentation and NER models on decision data from Freiburg"@en;
     dcat:accessURL "https://labelstudio.abb.ml2grow.cloud/projects/26/data?tab=68"^^xsd:anyURI
 .
 
 dataset:2ba4d174-e492-4bf2-b3a6-425f7afa51bf a dcat:Dataset;
     mu:uuid "2ba4d174-e492-4bf2-b3a6-425f7afa51bf";
-    dct:title "Bamberg NER and Segmentation dataset";
-    dct:description "A comprehensive dataset to train segmentation and NER models on decision data from Bamberg";
+    dct:title "Bamberg NER and Segmentation dataset"@en;
+    dct:description "A comprehensive dataset to train segmentation and NER models on decision data from Bamberg"@en;
     dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
     dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:distribution distribution:7125af8b-f298-44a5-9c5f-c3db1b296fbd
 .
@@ -322,18 +337,18 @@ distribution:7125af8b-f298-44a5-9c5f-c3db1b296fbd a dcat:Distribution;
     mu:uuid "7125af8b-f298-44a5-9c5f-c3db1b296fbd";
     rdfs:comment "Labelstudio";
     dct:format <http://publications.europa.eu/resource/authority/file-type/OCTET>;
-    dct:title "Bamberg NER and Segmentation dataset";
-    dct:description "Labelstudio data to train segmentation and NER models on decision data from Bamberg";
+    dct:title "Bamberg NER and Segmentation dataset"@en;
+    dct:description "Labelstudio data to train segmentation and NER models on decision data from Bamberg"@en;
     dcat:accessURL "https://labelstudio.abb.ml2grow.cloud/projects/31/data?tab=110"^^xsd:anyURI
 .
 
 dataset:b0d10410-8bd0-408d-81d1-5794296e3e1b a dcat:Dataset;
     mu:uuid "dataset:b0d10410-8bd0-408d-81d1-5794296e3e1b";
-    dct:title "Combined translated dataset";
-    dct:description "A comprehensive dataset to train segmentation and NER models on decision data from Bamberg, Freiburg and Ghent in English";
+    dct:title "Combined translated dataset"@en;
+    dct:description "A comprehensive dataset to train segmentation and NER models on decision data from Bamberg, Freiburg and Ghent in English"@en;
     dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
     dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:distribution distribution:ab53349d-155c-4ed4-ad5a-27404488b69b
 .
@@ -341,8 +356,8 @@ distribution:ab53349d-155c-4ed4-ad5a-27404488b69b a dcat:Distribution;
     mu:uuid "ab53349d-155c-4ed4-ad5a-27404488b69b";
     rdfs:comment "Labelstudio";
     dct:format <http://publications.europa.eu/resource/authority/file-type/OCTET>;
-    dct:title "Combined translated dataset";
-    dct:description "Labelstudio data to train segmentation and NER models on decision data from Bamberg, Freiburg and Ghent in English";
+    dct:title "Combined translated dataset"@en;
+    dct:description "Labelstudio data to train segmentation and NER models on decision data from Bamberg, Freiburg and Ghent in English"@en;
     dcat:accessURL "https://labelstudio.abb.ml2grow.cloud/projects/27/data?tab=74"^^xsd:anyURI
 .
 
@@ -352,9 +367,11 @@ distribution:ab53349d-155c-4ed4-ad5a-27404488b69b a dcat:Distribution;
 
 service:0993dd37-87d7-4c20-894b-f7e3ffc87b7c a dcat:DataService ;
     mu:uuid "0993dd37-87d7-4c20-894b-f7e3ffc87b7c";
-    dct:title "Internal SPARQL endpoint";
+    dct:title "Internal SPARQL endpoint"@en, "Intern SPARQL endpoint"@nl;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
+    dcat:endpointDescription "Internally available triple store for DECIDe"@en;
     dcat:endpointURL "http://database:8890/sparql"^^xsd:anyURI ;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:servesDataset
         dataset:16a89d3f-b75d-4dc8-bee8-69089f734c27,
         dataset:93951be6-e452-4579-807b-df5c969e333e,
@@ -363,11 +380,11 @@ service:0993dd37-87d7-4c20-894b-f7e3ffc87b7c a dcat:DataService ;
 
 dataset:16a89d3f-b75d-4dc8-bee8-69089f734c27 a dcat:Dataset;
     mu:uuid "16a89d3f-b75d-4dc8-bee8-69089f734c27";
-    dct:title "OSLO besluitdata";
-    dct:description "OSLO besluitdata geconsumeerd van Lokaal Beslists harvester 1. De data omvat agendapunten, behandelingen van agendapunten, besluiten, bestuursorganen, mandatarissen en stemmingen, en is onder andere afkomstig van alle Gentse bestuursorganen.";
+    dct:title "OSLO besluitdata"@nl;
+    dct:description "OSLO besluitdata geconsumeerd van Lokaal Beslists harvester 1. De data omvat agendapunten, behandelingen van agendapunten, besluiten, bestuursorganen, mandatarissen en stemmingen, en is onder andere afkomstig van alle Gentse bestuursorganen."@nl;
     dct:publisher agent:ABB;
     dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     prov:alternateOf dataset:cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6;
     dcat:distribution distribution:7ccb4d96-a5fe-466b-8d54-74dcd318db31
@@ -376,16 +393,16 @@ distribution:7ccb4d96-a5fe-466b-8d54-74dcd318db31 a dcat:Distribution;
     mu:uuid "7ccb4d96-a5fe-466b-8d54-74dcd318db31";
     dcat:accessURL "http://database:8890/sparqlD"^^xsd:anyURI;
     dcat:accessService service:0993dd37-87d7-4c20-894b-f7e3ffc87b7c;
-    rdfs:comment "Dit is rechtstraaks overgenomen van Lokaal Beslist harvester 1. De graph is enkel bereikbaar door ons op onze server (niet-publiek), maar de orginele Lokaal Beslist data is publiek. Data is opgeslagen in een graph (http://mu.semte.ch/graphs/oslo-decisions/landing) in triplestore op onze dev server"
+    rdfs:comment "Dit is rechtstraaks overgenomen van Lokaal Beslist harvester 1. De graph is enkel bereikbaar door ons op onze server (niet-publiek), maar de orginele Lokaal Beslist data is publiek. Data is opgeslagen in een graph (http://mu.semte.ch/graphs/oslo-decisions/landing) in triplestore op onze dev server"@nl
 .
 
 dataset:93951be6-e452-4579-807b-df5c969e333e a dcat:Dataset;
     mu:uuid "93951be6-e452-4579-807b-df5c969e333e";
-    dct:title "ELI besluitdata Gent";
-    dct:description "ELI besluitdata gebaseerd op Gentse OSLO besluitdata in Lokaal Beslist";
+    dct:title "ELI besluitdata Gent"@nl;
+    dct:description "ELI besluitdata gebaseerd op Gentse OSLO besluitdata in Lokaal Beslist"@nl;
     dct:publisher agent:ABB;
     dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
-    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:distribution distribution:c321d079-aa58-4732-a222-c3e9a76cdc8f
 .
@@ -414,18 +431,19 @@ dataset:ead64000-2c7d-4fcc-a255-fd1c3451f956 a dcat:Dataset;
 .
 distribution:33f42ce6-3278-438f-9463-37a9ab17b096 a dcat:Distribution;
     mu:uuid "33f42ce6-3278-438f-9463-37a9ab17b096";
-    dct:title "SPARQL endpoint DEV Decide";
-    dct:description "SPARQL endpoint on the Dev server of Decide";
+    dct:title "SPARQL endpoint DEV Decide"@en;
+    dct:description "SPARQL endpoint on the Dev server of Decide"@en;
     dcat:accessURL "http://database:8890/sparql"^^xsd:anyURI; # only internally available
     dcat:accessService service:0993dd37-87d7-4c20-894b-f7e3ffc87b7c;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>
 .
 
 
 distribution:743d147f-7079-4425-aa5b-0351dde216f4 a dcat:Distribution;
     mu:uuid "743d147f-7079-4425-aa5b-0351dde216f4";
-    dct:title "OParl-to-eli proxy (ELI)";
-    dct:description "Proxy API that provides OParl responses in ELI format on the fly";
+    dct:title "OParl-to-eli proxy (ELI)"@en;
+    dct:description "Proxy API that provides OParl responses in ELI format on the fly"@en;
     dcat:accessURL "https://vc.decide-dev.s.redhost.be/eli/eli"^^xsd:anyURI;
     dcat:accessService service:e27bea64-2c54-4dc0-8c6d-a6d4a1ed609b;
     dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE>;
@@ -433,7 +451,10 @@ distribution:743d147f-7079-4425-aa5b-0351dde216f4 a dcat:Distribution;
 .
 service:e27bea64-2c54-4dc0-8c6d-a6d4a1ed609b a dcat:DataService ;
     mu:uuid "e27bea64-2c54-4dc0-8c6d-a6d4a1ed609b";
+    dct:title "OParl-to-eli proxy (ELI)"@en;
+    dcat:endpointDescription "Proxy API that provides OParl responses in ELI format on the fly"@en;
     dcat:endpointURL "https://vc.decide-dev.s.redhost.be/eli/eli"^^xsd:anyURI ;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:ead64000-2c7d-4fcc-a255-fd1c3451f956
 .
 
@@ -448,8 +469,11 @@ distribution:46321676-74d9-4ab9-be29-83612ab7ec51 a dcat:Distribution;
 .
 service:a04a2727-d097-4297-93cc-1b3bfe7bf5e2 a dcat:DataService ;
     mu:uuid "a04a2727-d097-4297-93cc-1b3bfe7bf5e2";
+    dct:title "OParl API Freiburg"@en;
     dct:conformsTo <https://oparl.org/spezifikation/> ;
+    dcat:endpointDescription "OParl API is a JSON API offered by the vendor of Freiburg."@en ;
     dcat:endpointURL "https://ris.freiburg.de/oparl"^^xsd:anyURI ;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:ead64000-2c7d-4fcc-a255-fd1c3451f956
 .
 
@@ -489,8 +513,8 @@ dataset:8a84f8a5-613a-45d0-bd43-e430dd3516ce a dcat:Dataset;
 .
 distribution:7661627c-3cae-4991-bbdc-1f0a3f633781 a dcat:Distribution;
     mu:uuid "7661627c-3cae-4991-bbdc-1f0a3f633781";
-    dct:title "Bamberg PDFs on local decisions";
-    dct:description "Bamberg PDFs on local decisions.";
+    dct:title "Bamberg PDFs on local decisions"@en;
+    dct:description "Bamberg PDFs on local decisions."@en;
     dcat:accessURL "https://u486391-sub1.your-storagebox.de/home/datasets/bamberg/bamberg_pdfs"^^xsd:anyURI; # only internally available
     dct:format <http://publications.europa.eu/resource/authority/file-type/PDF>
 .

--- a/config/migrations/add-decide-datasets/20260108152100-overview.ttl
+++ b/config/migrations/add-decide-datasets/20260108152100-overview.ttl
@@ -63,7 +63,7 @@ agent:945e9df0-c9e6-4f5c-a249-34075169e68d a foaf:Agent;
     dct:issued "2025-10-16"^^xsd:date;
     dct:modified "2026-01-22"^^xsd:date;
     dct:language <http://publications.europa.eu/resource/authority/language/ENG>;
-    foaf:homepage "https://www.vlaanderen.be/lokaal-bestuur/digitale-transformatie/slimme-lokale-databronnen/decide"^^xsd:anyURI;
+    foaf:homepage <https://www.vlaanderen.be/lokaal-bestuur/digitale-transformatie/slimme-lokale-databronnen/decide>;
     dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:themeTaxonomy <https://vocab.belgif.be/auth/datatheme>;
     dcat:dataset
@@ -105,7 +105,7 @@ distribution:4697a3e9-9225-4ca1-a17c-0df585b4f872 a dcat:Distribution;
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
     dct:title "Lokaal Beslist SPARQL Endpoint 0"@nl, "Lokaal Beslist SPARQL Endpoint 0"@en;
     dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
-    dcat:accessURL "https://lokaalbeslist-harvester-0.s.redhost.be/sparql"^^xsd:anyURI;
+    dcat:accessURL <https://lokaalbeslist-harvester-0.s.redhost.be/sparql>;
     dcat:accessService service:df87f118-165c-468d-b558-99f5c324d334;
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
     dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
@@ -115,7 +115,7 @@ service:df87f118-165c-468d-b558-99f5c324d334 a dcat:DataService ;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
     dct:title "Lokaal Beslist SPARQL Endpoint 0"@nl, "Lokaal Beslist SPARQL Endpoint 0"@en;
     dcat:endpointDescription "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
-    dcat:endpointURL "https://lokaalbeslist-harvester-0.s.redhost.be/sparql"^^xsd:anyURI ;
+    dcat:endpointURL <https://lokaalbeslist-harvester-0.s.redhost.be/sparql> ;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:2bb49e25-feb1-4daf-b98a-6c274e7d6d7d
 .
@@ -135,7 +135,7 @@ distribution:3e9974a1-2182-404b-b60a-84a64468df31 a dcat:Distribution;
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
     dct:title "Lokaal Beslist SPARQL Endpoint 1"@nl, "Lokaal Beslist SPARQL Endpoint 1"@en;;
     dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
-    dcat:accessURL "https://lokaalbeslist-harvester-1.s.redhost.be/sparql"^^xsd:anyURI;
+    dcat:accessURL <https://lokaalbeslist-harvester-1.s.redhost.be/sparql>;
     dcat:accessService service:57638b91-d88b-44cb-9664-61d108bb92e7;
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
     dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
@@ -145,7 +145,7 @@ service:57638b91-d88b-44cb-9664-61d108bb92e7 a dcat:DataService ;
     dct:title "Lokaal Beslist Harvester 1"@nl, "Lokaal Beslist Harvester 2"@en;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
     dcat:endpointDescription "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
-    dcat:endpointURL "https://lokaalbeslist-harvester-1.s.redhost.be/sparql"^^xsd:anyURI ;
+    dcat:endpointURL <https://lokaalbeslist-harvester-1.s.redhost.be/sparql> ;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6
 .
@@ -165,7 +165,7 @@ distribution:e5f475b5-c6d3-4ff2-b8fc-0a81003138a0 a dcat:Distribution;
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
     dct:title "Lokaal Beslist SPARQL Endpoint 2"@nl, "Lokaal Beslist SPARQL Endpoint 2"@en;
     dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
-    dcat:accessURL "https://lokaalbeslist-harvester-2.s.redhost.be/sparql"^^xsd:anyURI;
+    dcat:accessURL <https://lokaalbeslist-harvester-2.s.redhost.be/sparql>;
     dcat:accessService service:706a5fda-ef6e-496e-a312-15a0620efe12;
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
     dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
@@ -175,7 +175,7 @@ service:706a5fda-ef6e-496e-a312-15a0620efe12 a dcat:DataService ;
     dct:title "Lokaal Beslist Harvester 2"@nl, "Lokaal Beslist Harvester 2"@en;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
     dcat:endpointDescription "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
-    dcat:endpointURL "https://lokaalbeslist-harvester-2.s.redhost.be/sparql"^^xsd:anyURI ;
+    dcat:endpointURL <https://lokaalbeslist-harvester-2.s.redhost.be/sparql> ;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:0b2ad45a-eccf-45ac-874d-8b498a172772
 .
@@ -195,7 +195,7 @@ distribution:19bada3c-fc39-4524-a692-d45e735f578f a dcat:Distribution;
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
     dct:title "Lokaal Beslist SPARQL Endpoint 3"@nl, "Lokaal Beslist SPARQL Endpoint 3"@en;
     dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
-    dcat:accessURL "https://lokaalbeslist-harvester-3.s.redhost.be/sparql"^^xsd:anyURI;
+    dcat:accessURL <https://lokaalbeslist-harvester-3.s.redhost.be/sparql>;
     dcat:accessService service:ec5feb51-9108-4c35-adef-d799f64bab9d;
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
     dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
@@ -205,7 +205,7 @@ service:ec5feb51-9108-4c35-adef-d799f64bab9d a dcat:DataService ;
     dct:title "Lokaal Beslist SPARQL Endpoint 3"@nl, "Lokaal Beslist SPARQL Endpoint 3"@en;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
     dcat:endpointDescription "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
-    dcat:endpointURL "https://lokaalbeslist-harvester-3.s.redhost.be/sparql"^^xsd:anyURI ;
+    dcat:endpointURL <https://lokaalbeslist-harvester-3.s.redhost.be/sparql> ;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:f7a4bbb3-1fef-4975-9049-ee933cfce30e
 .
@@ -226,7 +226,7 @@ dataset:74c12f17-f0eb-4bf2-8390-0d21655f00e3 a dcat:Dataset;
 distribution:ad94e41e-a790-44bc-8602-e1fe0c7bc1b0 a dcat:Distribution;
     mu:uuid "ad94e41e-a790-44bc-8602-e1fe0c7bc1b0";
     dct:title "Open Proces Huis SPARQL endpoint"@nl, "Open Proces Huis SPARQL endpoint"@en;
-    dcat:accessURL "https://openproceshuis.vlaanderen.be/sparql"^^xsd:anyURI;
+    dcat:accessURL <https://openproceshuis.vlaanderen.be/sparql>;
     dcat:accessService service:7333d62b-bd34-4063-ad34-28ec22a098b5;
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>
 .
@@ -235,7 +235,7 @@ service:7333d62b-bd34-4063-ad34-28ec22a098b5 a dcat:DataService ;
     dct:title "Open Proces Huis SPARQL Endpoint"@nl, "Open Proces Huis SPARQL Endpoint"@en;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
     dcat:endpointDescription "Proces-, diagram- en inventarisdata van Open Proces Huis"@nl, "Process, diagram and inventory data of Open Proces Huis"@en;
-    dcat:endpointURL "https://openproceshuis.vlaanderen.be/sparql"^^xsd:anyURI ;
+    dcat:endpointURL <https://openproceshuis.vlaanderen.be/sparql> ;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:servesDataset dataset:74c12f17-f0eb-4bf2-8390-0d21655f00e3
 .
@@ -259,7 +259,7 @@ distribution:f27a58aa-5cbf-4612-b3d0-a4d49100153f a dcat:Distribution;
     dct:format <http://publications.europa.eu/resource/authority/file-type/PARQUET>;
     dct:title "Ghent Municipal Decisions Roadblocks Classification"@en;
     dct:description "HuggingFace data of Dutch municipal decision documents from Ghent, Belgium, specifically processed and classified for traffic measures, roadblocks, and infrastructure projects that affect urban mobility."@en;
-    dcat:accessURL "https://huggingface.co/datasets/svercoutere/abb-decide-ghent-roadblocks-classification"^^xsd:anyURI
+    dcat:accessURL <https://huggingface.co/datasets/svercoutere/abb-decide-ghent-roadblocks-classification>
 .
 
 dataset:2e1d52d9-2509-4b60-ac5a-0307897d64ef a dcat:Dataset;
@@ -278,7 +278,7 @@ distribution:4ed47dd1-aa35-4f94-b751-c0984349908c a dcat:Distribution;
     dct:format <http://publications.europa.eu/resource/authority/file-type/PARQUET>;
     dct:title "llama3 ABB Instruct"@en;
     dct:description "HuggingFace data to fine tune a llama3 model for translation, classification and keyword extraction from decision documents from Ghent"@en;
-    dcat:accessURL "https://huggingface.co/datasets/svercoutere/llama3_abb_instruct_dataset"^^xsd:anyURI
+    dcat:accessURL <https://huggingface.co/datasets/svercoutere/llama3_abb_instruct_dataset>
 .
 
 dataset:6aaa542d-410c-4150-bcfd-e5526eab87f4 a dcat:Dataset;
@@ -297,7 +297,7 @@ distribution:6d5607a1-e1b3-4259-b186-760d8fef7da3 a dcat:Distribution;
     dct:format <http://publications.europa.eu/resource/authority/file-type/PARQUET>;
     dct:title "ABB DECIDe SDGs Antwerp"@en;
     dct:description "HuggingFace data to classify decision documents from Antwerp into Sustainable Development Goals"@en;
-    dcat:accessURL "https://huggingface.co/datasets/svercoutere/abb-decide-sdgs-antwerp"^^xsd:anyURI
+    dcat:accessURL <https://huggingface.co/datasets/svercoutere/abb-decide-sdgs-antwerp>
 .
 
 dataset:3d79b143-4009-451a-8b80-423da944d9a8 a dcat:Dataset;
@@ -316,7 +316,7 @@ distribution:b8b63c96-f5ce-496a-937e-7406f6aa1b91 a dcat:Distribution;
     dct:format <http://publications.europa.eu/resource/authority/file-type/PARQUET>;
     dct:title "ABB DECIDe title extraction instruct"@en;
     dct:description "HuggingFace data to identify and extract the title from plain text decision documents from Ghent with the help of llama3"@en;
-    dcat:accessURL "https://huggingface.co/datasets/PedroDKE/ABB-DECIDe-title-extraction-instruct-dataset"^^xsd:anyURI
+    dcat:accessURL <https://huggingface.co/datasets/PedroDKE/ABB-DECIDe-title-extraction-instruct-dataset>
 .
 
 dataset:6b65a734-7d22-4486-97e3-c7eafc7341d5 a dcat:Dataset;
@@ -335,7 +335,7 @@ distribution:a9233283-4233-41b0-a4e4-ab470c49a6f6 a dcat:Distribution;
     dct:format <http://publications.europa.eu/resource/authority/file-type/OCTET>;
     dct:title "Flanders NER and Segmentation dataset"@en;
     dct:description "Labelstudio data to train segmentation and NER models on decision data from Flemish cities"@en;
-    dcat:accessURL "https://labelstudio.abb.ml2grow.cloud/projects/25/data?tab=73"^^xsd:anyURI
+    dcat:accessURL <https://labelstudio.abb.ml2grow.cloud/projects/25/data?tab=73>
 .
 
 dataset:38fd6817-f185-478d-9e21-12d6a694834c a dcat:Dataset;
@@ -354,7 +354,7 @@ distribution:66b310c8-4d2b-4f8f-a292-c1882f939e6c a dcat:Distribution;
     dct:format <http://publications.europa.eu/resource/authority/file-type/OCTET>;
     dct:title "Freiburg NER and Segmentation dataset"@en;
     dct:description "Labelstudio data to train segmentation and NER models on decision data from Freiburg"@en;
-    dcat:accessURL "https://labelstudio.abb.ml2grow.cloud/projects/26/data?tab=68"^^xsd:anyURI
+    dcat:accessURL <https://labelstudio.abb.ml2grow.cloud/projects/26/data?tab=68>
 .
 
 dataset:2ba4d174-e492-4bf2-b3a6-425f7afa51bf a dcat:Dataset;
@@ -373,7 +373,7 @@ distribution:7125af8b-f298-44a5-9c5f-c3db1b296fbd a dcat:Distribution;
     dct:format <http://publications.europa.eu/resource/authority/file-type/OCTET>;
     dct:title "Bamberg NER and Segmentation dataset"@en;
     dct:description "Labelstudio data to train segmentation and NER models on decision data from Bamberg"@en;
-    dcat:accessURL "https://labelstudio.abb.ml2grow.cloud/projects/31/data?tab=110"^^xsd:anyURI
+    dcat:accessURL <https://labelstudio.abb.ml2grow.cloud/projects/31/data?tab=110>
 .
 
 dataset:b0d10410-8bd0-408d-81d1-5794296e3e1b a dcat:Dataset;
@@ -392,7 +392,7 @@ distribution:ab53349d-155c-4ed4-ad5a-27404488b69b a dcat:Distribution;
     dct:format <http://publications.europa.eu/resource/authority/file-type/OCTET>;
     dct:title "Combined translated dataset"@en;
     dct:description "Labelstudio data to train segmentation and NER models on decision data from Bamberg, Freiburg and Ghent in English"@en;
-    dcat:accessURL "https://labelstudio.abb.ml2grow.cloud/projects/27/data?tab=74"^^xsd:anyURI
+    dcat:accessURL <https://labelstudio.abb.ml2grow.cloud/projects/27/data?tab=74>
 .
 
 
@@ -476,7 +476,7 @@ distribution:743d147f-7079-4425-aa5b-0351dde216f4 a dcat:Distribution;
     mu:uuid "743d147f-7079-4425-aa5b-0351dde216f4";
     dct:title "OParl-to-eli proxy (ELI)"@en;
     dct:description "Proxy API that provides OParl responses in ELI format on the fly"@en;
-    dcat:accessURL "https://vc.decide-dev.s.redhost.be/eli/eli"^^xsd:anyURI;
+    dcat:accessURL <https://vc.decide-dev.s.redhost.be/eli/eli>;
     dcat:accessService service:e27bea64-2c54-4dc0-8c6d-a6d4a1ed609b;
     dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE>;
     rdfs:comment "REST (HTTP + Turtle)"
@@ -485,7 +485,7 @@ service:e27bea64-2c54-4dc0-8c6d-a6d4a1ed609b a dcat:DataService ;
     mu:uuid "e27bea64-2c54-4dc0-8c6d-a6d4a1ed609b";
     dct:title "OParl-to-eli proxy (ELI)"@en;
     dcat:endpointDescription "Proxy API that provides OParl responses in ELI format on the fly"@en;
-    dcat:endpointURL "https://vc.decide-dev.s.redhost.be/eli/eli"^^xsd:anyURI ;
+    dcat:endpointURL <https://vc.decide-dev.s.redhost.be/eli/eli> ;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:ead64000-2c7d-4fcc-a255-fd1c3451f956
 .
@@ -494,7 +494,7 @@ distribution:46321676-74d9-4ab9-be29-83612ab7ec51 a dcat:Distribution;
     mu:uuid "46321676-74d9-4ab9-be29-83612ab7ec51";
     dct:title "OParl API Freiburg"@en;
     dct:description "OParl API is a JSON API offered by the vendor of Freiburg. The OParl specification can be found here: https://oparl.org/spezifikation/"@en;
-    dcat:accessURL "https://ris.freiburg.de/oparl"^^xsd:anyURI;
+    dcat:accessURL <https://ris.freiburg.de/oparl>;
     dcat:accessService service:a04a2727-d097-4297-93cc-1b3bfe7bf5e2;
     dct:format <http://publications.europa.eu/resource/authority/file-type/JSON>;
     rdfs:comment "REST (HTTP + JSON)"
@@ -504,7 +504,7 @@ service:a04a2727-d097-4297-93cc-1b3bfe7bf5e2 a dcat:DataService ;
     dct:title "OParl API Freiburg"@en;
     dct:conformsTo <https://oparl.org/spezifikation/> ;
     dcat:endpointDescription "OParl API is a JSON API offered by the vendor of Freiburg."@en ;
-    dcat:endpointURL "https://ris.freiburg.de/oparl"^^xsd:anyURI ;
+    dcat:endpointURL <https://ris.freiburg.de/oparl> ;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:ead64000-2c7d-4fcc-a255-fd1c3451f956
 .
@@ -520,14 +520,14 @@ dataset:3840171f-daf5-4efe-bf42-e7d511e6a1c1 a dcat:Dataset;
     dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
-    rdfs:seeAlso "https://app.gitbook.com/o/-MP9Yduzf5xu7wIebqPG/s/grRYjcouX0uZY2P6PYBl/ai-analysis-research/ai-approach-uc-0.0/named-entity-recognition"^^xsd:anyURI;
+    rdfs:seeAlso <https://app.gitbook.com/o/-MP9Yduzf5xu7wIebqPG/s/grRYjcouX0uZY2P6PYBl/ai-analysis-research/ai-approach-uc-0.0/named-entity-recognition>;
     dcat:distribution distribution:db4e1b76-1a09-45fa-99be-32ddc5840a37
 .
 distribution:db4e1b76-1a09-45fa-99be-32ddc5840a37 a dcat:Distribution;
     mu:uuid "db4e1b76-1a09-45fa-99be-32ddc5840a37";
     dct:title "Freiburg PDFs on local decisions"@en;
     dct:description "Freiburg PDFs on local decisions"@en;
-    dcat:accessURL "https://u486391-sub1.your-storagebox.de/home/datasets/freiburg/freiburg_pdfs"^^xsd:anyURI;
+    dcat:accessURL <https://u486391-sub1.your-storagebox.de/home/datasets/freiburg/freiburg_pdfs>;
     dct:format <http://publications.europa.eu/resource/authority/file-type/PDF>
 .
 
@@ -546,6 +546,6 @@ distribution:7661627c-3cae-4991-bbdc-1f0a3f633781 a dcat:Distribution;
     mu:uuid "7661627c-3cae-4991-bbdc-1f0a3f633781";
     dct:title "Bamberg PDFs on local decisions"@en;
     dct:description "Bamberg PDFs on local decisions."@en;
-    dcat:accessURL "https://u486391-sub1.your-storagebox.de/home/datasets/bamberg/bamberg_pdfs"^^xsd:anyURI;
+    dcat:accessURL <https://u486391-sub1.your-storagebox.de/home/datasets/bamberg/bamberg_pdfs>;
     dct:format <http://publications.europa.eu/resource/authority/file-type/PDF>
 .

--- a/config/migrations/add-decide-datasets/20260108152100-overview.ttl
+++ b/config/migrations/add-decide-datasets/20260108152100-overview.ttl
@@ -34,7 +34,7 @@ agent:658900ce-63cf-4d45-8fd5-a67ed8deab2c a foaf:Agent;
 .
 
 agent:c3c2a7bf-af3b-43b8-99f5-c3463ec9408a a foaf:Agent;
-    vcard:hasName "Vlaamse Overheid"@nl
+    vcard:hasName "Vlaamse Overheid"@nl, "Flemish government"@en
 .
 
 agent:f45c1220-b250-4b93-8a8a-3e7e4a12a467 a foaf:Agent;
@@ -63,9 +63,9 @@ agent:945e9df0-c9e6-4f5c-a249-34075169e68d a foaf:Agent;
 
 dataset:2bb49e25-feb1-4daf-b98a-6c274e7d6d7d a dcat:Dataset;
     mu:uuid "2bb49e25-feb1-4daf-b98a-6c274e7d6d7d";
-    dct:title "Lokaal Beslist Harvester 0"@nl;
-    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
-    dct:publisher agent:;
+    dct:title "Lokaal Beslist Harvester 0"@nl, "Lokaal Beslist Harvester 0"@en;
+    dct:description "Lokale besluiten van Vlaamse gemeenten"@nl, "Local decisions of Flemish municipalities"@en;
+    dct:publisher agent:436c5bce-8380-401e-8027-f34ef4acd97e;
     dcat:contactPoint agent:436c5bce-8380-401e-8027-f34ef4acd97e;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
@@ -74,17 +74,18 @@ dataset:2bb49e25-feb1-4daf-b98a-6c274e7d6d7d a dcat:Dataset;
 distribution:4697a3e9-9225-4ca1-a17c-0df585b4f872 a dcat:Distribution;
     mu:uuid "4697a3e9-9225-4ca1-a17c-0df585b4f872";
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
-    dct:title "Lokaal Beslist SPARQL Endpoint 0"@nl;
-    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten"@nl;
+    dct:title "Lokaal Beslist SPARQL Endpoint 0"@nl, "Lokaal Beslist SPARQL Endpoint 0"@en;
+    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
     dcat:accessURL "https://lokaalbeslist-harvester-0.s.redhost.be/sparql"^^xsd:anyURI;
     dcat:accessService service:df87f118-165c-468d-b558-99f5c324d334;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
     dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
 .
 service:df87f118-165c-468d-b558-99f5c324d334 a dcat:DataService ;
     mu:uuid "df87f118-165c-468d-b558-99f5c324d334";
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
-    dct:title "Lokaal Beslist SPARQL Endpoint 0"@nl;
-    dcat:endpointDescription "Endpoint met lokale besluiten van Vlaamse gemeenten"@nl;
+    dct:title "Lokaal Beslist SPARQL Endpoint 0"@nl, "Lokaal Beslist SPARQL Endpoint 0"@en;
+    dcat:endpointDescription "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
     dcat:endpointURL "https://lokaalbeslist-harvester-0.s.redhost.be/sparql"^^xsd:anyURI ;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:2bb49e25-feb1-4daf-b98a-6c274e7d6d7d
@@ -93,7 +94,7 @@ service:df87f118-165c-468d-b558-99f5c324d334 a dcat:DataService ;
 dataset:cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6 a dcat:Dataset;
     mu:uuid "cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6";
     dct:title "Lokaal Beslist Harvester 1"@nl;
-    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
+    dct:description "Lokale besluiten van Vlaamse gemeenten"@nl, "Local decisions of Flemish municipalities"@en;
     dct:publisher agent:436c5bce-8380-401e-8027-f34ef4acd97e;
     dcat:contactPoint agent:436c5bce-8380-401e-8027-f34ef4acd97e;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
@@ -103,17 +104,18 @@ dataset:cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6 a dcat:Dataset;
 distribution:3e9974a1-2182-404b-b60a-84a64468df31 a dcat:Distribution;
     mu:uuid "3e9974a1-2182-404b-b60a-84a64468df31";
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
-    dct:title "Lokaal Beslist SPARQL Endpoint 1"@nl;
-    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
+    dct:title "Lokaal Beslist SPARQL Endpoint 1"@nl, "Lokaal Beslist SPARQL Endpoint 1"@en;;
+    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
     dcat:accessURL "https://lokaalbeslist-harvester-1.s.redhost.be/sparql"^^xsd:anyURI;
     dcat:accessService service:57638b91-d88b-44cb-9664-61d108bb92e7;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
     dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
 .
 service:57638b91-d88b-44cb-9664-61d108bb92e7 a dcat:DataService ;
     mu:uuid "57638b91-d88b-44cb-9664-61d108bb92e7";
-    dct:title "Lokaal Beslist Harvester 1"@nl;
+    dct:title "Lokaal Beslist Harvester 1"@nl, "Lokaal Beslist Harvester 2"@en;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
-    dcat:endpointDescription "Endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
+    dcat:endpointDescription "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
     dcat:endpointURL "https://lokaalbeslist-harvester-1.s.redhost.be/sparql"^^xsd:anyURI ;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6
@@ -121,8 +123,8 @@ service:57638b91-d88b-44cb-9664-61d108bb92e7 a dcat:DataService ;
 
 dataset:0b2ad45a-eccf-45ac-874d-8b498a172772 a dcat:Dataset;
     mu:uuid "0b2ad45a-eccf-45ac-874d-8b498a172772";
-    dct:title "Lokaal Beslist Harvester 2"@nl;
-    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
+    dct:title "Lokaal Beslist Harvester 2"@nl, "Lokaal Beslist Harvester 2"@en;
+    dct:description "Lokale besluiten van Vlaamse gemeenten"@nl, "Local decisions of Flemish municipalities"@en;
     dct:publisher agent:436c5bce-8380-401e-8027-f34ef4acd97e;
     dcat:contactPoint agent:436c5bce-8380-401e-8027-f34ef4acd97e;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
@@ -132,17 +134,18 @@ dataset:0b2ad45a-eccf-45ac-874d-8b498a172772 a dcat:Dataset;
 distribution:e5f475b5-c6d3-4ff2-b8fc-0a81003138a0 a dcat:Distribution;
     mu:uuid "e5f475b5-c6d3-4ff2-b8fc-0a81003138a0";
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
-    dct:title "Lokaal Beslist SPARQL Endpoint 2"@nl;
-    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
+    dct:title "Lokaal Beslist SPARQL Endpoint 2"@nl, "Lokaal Beslist SPARQL Endpoint 2"@en;
+    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
     dcat:accessURL "https://lokaalbeslist-harvester-2.s.redhost.be/sparql"^^xsd:anyURI;
     dcat:accessService service:706a5fda-ef6e-496e-a312-15a0620efe12;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
     dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
 .
 service:706a5fda-ef6e-496e-a312-15a0620efe12 a dcat:DataService ;
     mu:uuid "706a5fda-ef6e-496e-a312-15a0620efe12";
-    dct:title "Lokaal Beslist Harvester 2"@nl;
+    dct:title "Lokaal Beslist Harvester 2"@nl, "Lokaal Beslist Harvester 2"@en;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
-    dcat:endpointDescription "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
+    dcat:endpointDescription "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
     dcat:endpointURL "https://lokaalbeslist-harvester-2.s.redhost.be/sparql"^^xsd:anyURI ;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:0b2ad45a-eccf-45ac-874d-8b498a172772
@@ -150,8 +153,8 @@ service:706a5fda-ef6e-496e-a312-15a0620efe12 a dcat:DataService ;
 
 dataset:f7a4bbb3-1fef-4975-9049-ee933cfce30e a dcat:Dataset;
     mu:uuid "f7a4bbb3-1fef-4975-9049-ee933cfce30e";
-    dct:title "Lokaal Beslist Harvester 3"@nl;
-    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
+    dct:title "Lokaal Beslist Harvester 3"@nl, "Lokaal Beslist Harvester 3"@en;
+    dct:description "Lokale besluiten van Vlaamse gemeenten"@nl, "Local decisions of Flemish municipalities"@en;
     dct:publisher agent:436c5bce-8380-401e-8027-f34ef4acd97e;
     dcat:contactPoint agent:436c5bce-8380-401e-8027-f34ef4acd97e;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
@@ -161,17 +164,18 @@ dataset:f7a4bbb3-1fef-4975-9049-ee933cfce30e a dcat:Dataset;
 distribution:19bada3c-fc39-4524-a692-d45e735f578f a dcat:Distribution;
     mu:uuid "19bada3c-fc39-4524-a692-d45e735f578f";
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
-    dct:title "Lokaal Beslist SPARQL Endpoint 3"@nl;
-    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
+    dct:title "Lokaal Beslist SPARQL Endpoint 3"@nl, "Lokaal Beslist SPARQL Endpoint 3"@en;
+    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
     dcat:accessURL "https://lokaalbeslist-harvester-3.s.redhost.be/sparql"^^xsd:anyURI;
     dcat:accessService service:ec5feb51-9108-4c35-adef-d799f64bab9d;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
     dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
 .
 service:ec5feb51-9108-4c35-adef-d799f64bab9d a dcat:DataService ;
     mu:uuid "ec5feb51-9108-4c35-adef-d799f64bab9d";
-    dct:title "Lokaal Beslist SPARQL Endpoint 3"@nl;
+    dct:title "Lokaal Beslist SPARQL Endpoint 3"@nl, "Lokaal Beslist SPARQL Endpoint 3"@en;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
-    dcat:endpointDescription "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten."@nl;
+    dcat:endpointDescription "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten"@nl, "SPARQL endpoint containing local decisions of Flemish municipalities"@en;
     dcat:endpointURL "https://lokaalbeslist-harvester-3.s.redhost.be/sparql"^^xsd:anyURI ;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dcat:servesDataset dataset:f7a4bbb3-1fef-4975-9049-ee933cfce30e
@@ -183,7 +187,7 @@ service:ec5feb51-9108-4c35-adef-d799f64bab9d a dcat:DataService ;
 dataset:74c12f17-f0eb-4bf2-8390-0d21655f00e3 a dcat:Dataset;
     mu:uuid "74c12f17-f0eb-4bf2-8390-0d21655f00e3";
     dct:title "Open Proces Huis procesdata"@nl;
-    dct:description "Proces-, diagram- en invatarisdata van Open Proces Huis"@nl;
+    dct:description "Proces-, diagram- en inventarisdata van Open Proces Huis"@nl, "Process, diagram and inventory data of Open Proces Huis"@en;
     dct:publisher agent:f45c1220-b250-4b93-8a8a-3e7e4a12a467;
     dcat:contactPoint agent:945e9df0-c9e6-4f5c-a249-34075169e68d;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
@@ -192,17 +196,18 @@ dataset:74c12f17-f0eb-4bf2-8390-0d21655f00e3 a dcat:Dataset;
 .
 distribution:ad94e41e-a790-44bc-8602-e1fe0c7bc1b0 a dcat:Distribution;
     mu:uuid "ad94e41e-a790-44bc-8602-e1fe0c7bc1b0";
-    dct:title "SPARQL endpoint"@nl;
+    dct:title "Open Proces Huis SPARQL endpoint"@nl, "Open Proces Huis SPARQL endpoint"@en;
     dcat:accessURL "https://openproceshuis.vlaanderen.be/sparql"^^xsd:anyURI;
-    dcat:accessService service:7333d62b-bd34-4063-ad34-28ec22a098b5
+    dcat:accessService service:7333d62b-bd34-4063-ad34-28ec22a098b5;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>
 .
 service:7333d62b-bd34-4063-ad34-28ec22a098b5 a dcat:DataService ;
     mu:uuid "7333d62b-bd34-4063-ad34-28ec22a098b5";
-    dct:title "Open Proces Huis procesdata"@nl;
+    dct:title "Open Proces Huis SPARQL Endpoint"@nl, "Open Proces Huis SPARQL Endpoint"@en;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
-    dcat:endpointDescription "Proces-, diagram- en invatarisdata van Open Proces Huis"@nl;
+    dcat:endpointDescription "Proces-, diagram- en inventarisdata van Open Proces Huis"@nl, "Process, diagram and inventory data of Open Proces Huis"@en;
     dcat:endpointURL "https://openproceshuis.vlaanderen.be/sparql"^^xsd:anyURI ;
-    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:servesDataset dataset:74c12f17-f0eb-4bf2-8390-0d21655f00e3
 .
 
@@ -369,8 +374,8 @@ service:0993dd37-87d7-4c20-894b-f7e3ffc87b7c a dcat:DataService ;
     mu:uuid "0993dd37-87d7-4c20-894b-f7e3ffc87b7c";
     dct:title "Internal SPARQL endpoint"@en, "Intern SPARQL endpoint"@nl;
     dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
-    dcat:endpointDescription "Internally available triple store for DECIDe"@en;
-    dcat:endpointURL "http://database:8890/sparql"^^xsd:anyURI ;
+    dcat:endpointDescription "Internally available triple store for DECIDe."@en;
+    rdfs:comment "Within the internal stack, available at http://database:8890/sparql"@en;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:servesDataset
         dataset:16a89d3f-b75d-4dc8-bee8-69089f734c27,
@@ -382,7 +387,7 @@ dataset:16a89d3f-b75d-4dc8-bee8-69089f734c27 a dcat:Dataset;
     mu:uuid "16a89d3f-b75d-4dc8-bee8-69089f734c27";
     dct:title "OSLO besluitdata"@nl;
     dct:description "OSLO besluitdata geconsumeerd van Lokaal Beslists harvester 1. De data omvat agendapunten, behandelingen van agendapunten, besluiten, bestuursorganen, mandatarissen en stemmingen, en is onder andere afkomstig van alle Gentse bestuursorganen."@nl;
-    dct:publisher agent:ABB;
+    dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
@@ -391,16 +396,16 @@ dataset:16a89d3f-b75d-4dc8-bee8-69089f734c27 a dcat:Dataset;
 .
 distribution:7ccb4d96-a5fe-466b-8d54-74dcd318db31 a dcat:Distribution;
     mu:uuid "7ccb4d96-a5fe-466b-8d54-74dcd318db31";
-    dcat:accessURL "http://database:8890/sparqlD"^^xsd:anyURI;
     dcat:accessService service:0993dd37-87d7-4c20-894b-f7e3ffc87b7c;
-    rdfs:comment "Dit is rechtstraaks overgenomen van Lokaal Beslist harvester 1. De graph is enkel bereikbaar door ons op onze server (niet-publiek), maar de orginele Lokaal Beslist data is publiek. Data is opgeslagen in een graph (http://mu.semte.ch/graphs/oslo-decisions/landing) in triplestore op onze dev server"@nl
+    dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
+    rdfs:comment "Dit is rechtstreeks overgenomen van Lokaal Beslist harvester 1. De graph is enkel bereikbaar door ons op onze server (niet-publiek), maar de orginele Lokaal Beslist data is publiek. Data is opgeslagen in een graph (http://mu.semte.ch/graphs/oslo-decisions/landing) in triplestore op onze dev server"@nl
 .
 
 dataset:93951be6-e452-4579-807b-df5c969e333e a dcat:Dataset;
     mu:uuid "93951be6-e452-4579-807b-df5c969e333e";
-    dct:title "ELI besluitdata Gent"@nl;
-    dct:description "ELI besluitdata gebaseerd op Gentse OSLO besluitdata in Lokaal Beslist"@nl;
-    dct:publisher agent:ABB;
+    dct:title "ELI besluitdata Gent"@nl, "ELI decision data Ghent";
+    dct:description "ELI besluitdata gebaseerd op Gentse OSLO besluitdata in Lokaal Beslist"@nl, "ELI decision data based on OSLO decision data from Ghent in Lokaal Beslist"@en;
+    dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
     dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
@@ -408,8 +413,8 @@ dataset:93951be6-e452-4579-807b-df5c969e333e a dcat:Dataset;
 .
 distribution:c321d079-aa58-4732-a222-c3e9a76cdc8f a dcat:Distribution;
     mu:uuid "c321d079-aa58-4732-a222-c3e9a76cdc8f";
-    dcat:accessURL "http://database:8890/sparql"^^xsd:anyURI;
     dcat:accessService service:0993dd37-87d7-4c20-894b-f7e3ffc87b7c;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
     rdfs:comment "Data is opgeslagen in een graph (http://mu.semte.ch/graphs/eli-decisions/ghent) in triplestore op onze dev server"
 .
 
@@ -423,7 +428,7 @@ dataset:ead64000-2c7d-4fcc-a255-fd1c3451f956 a dcat:Dataset;
     dct:publisher agent:658900ce-63cf-4d45-8fd5-a67ed8deab2c;
     dcat:contactPoint agent:7365f73a-b57c-4999-aa8b-61464d9d3c6f;
     dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
-    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
     dcat:distribution
         distribution:33f42ce6-3278-438f-9463-37a9ab17b096,
         distribution:743d147f-7079-4425-aa5b-0351dde216f4,
@@ -433,9 +438,7 @@ distribution:33f42ce6-3278-438f-9463-37a9ab17b096 a dcat:Distribution;
     mu:uuid "33f42ce6-3278-438f-9463-37a9ab17b096";
     dct:title "SPARQL endpoint DEV Decide"@en;
     dct:description "SPARQL endpoint on the Dev server of Decide"@en;
-    dcat:accessURL "http://database:8890/sparql"^^xsd:anyURI; # only internally available
     dcat:accessService service:0993dd37-87d7-4c20-894b-f7e3ffc87b7c;
-    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
     dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>
 .
 
@@ -495,7 +498,6 @@ distribution:db4e1b76-1a09-45fa-99be-32ddc5840a37 a dcat:Distribution;
     mu:uuid "db4e1b76-1a09-45fa-99be-32ddc5840a37";
     dct:title "Freiburg PDFs on local decisions"@en;
     dct:description "Freiburg PDFs on local decisions"@en;
-    rdfs:comment "Only internally available."@en;
     dcat:accessURL "https://u486391-sub1.your-storagebox.de/home/datasets/freiburg/freiburg_pdfs"^^xsd:anyURI;
     dct:format <http://publications.europa.eu/resource/authority/file-type/PDF>
 .
@@ -515,6 +517,6 @@ distribution:7661627c-3cae-4991-bbdc-1f0a3f633781 a dcat:Distribution;
     mu:uuid "7661627c-3cae-4991-bbdc-1f0a3f633781";
     dct:title "Bamberg PDFs on local decisions"@en;
     dct:description "Bamberg PDFs on local decisions."@en;
-    dcat:accessURL "https://u486391-sub1.your-storagebox.de/home/datasets/bamberg/bamberg_pdfs"^^xsd:anyURI; # only internally available
+    dcat:accessURL "https://u486391-sub1.your-storagebox.de/home/datasets/bamberg/bamberg_pdfs"^^xsd:anyURI;
     dct:format <http://publications.europa.eu/resource/authority/file-type/PDF>
 .

--- a/config/migrations/add-decide-datasets/20260108152100-overview.ttl
+++ b/config/migrations/add-decide-datasets/20260108152100-overview.ttl
@@ -1,25 +1,25 @@
-PREFIX adms: <http://www.w3.org/ns/adms#>
-PREFIX cms: <http://mu.semte.ch/vocabulary/cms/>
-PREFIX dcat: <http://www.w3.org/ns/dcat#>
-PREFIX dcatap: <http://data.europa.eu/r5r/>
-PREFIX dct: <http://purl.org/dc/terms/>
-PREFIX eurovoc: <http://eurovoc.europa.eu/>
-PREFIX ex: <http://example.org/>
-PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-PREFIX ldes: <https://w3id.org/ldes#>
-PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-PREFIX odrl: <https://www.w3.org/TR/odrl-vocab/>
-PREFIX owl: <http://www.w3.org/2002/07/owl#>
-PREFIX prov: <http://www.w3.org/ns/prov#>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-PREFIX agent: <http://data.lblod.info/id/agents/>
-PREFIX dataset: <http://data.lblod.info/id/datasets/>
-PREFIX distribution: <http://data.lblod.info/id/distributions/>
-PREFIX service: <http://data.lblod.info/id/services/>
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix cms: <http://mu.semte.ch/vocabulary/cms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dcatap: <http://data.europa.eu/r5r/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix eurovoc: <http://eurovoc.europa.eu/> .
+@prefix ex: <http://example.org/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ldes: <https://w3id.org/ldes#> .
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix odrl: <https://www.w3.org/TR/odrl-vocab/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix agent: <http://data.lblod.info/id/agents/> .
+@prefix dataset: <http://data.lblod.info/id/datasets/> .
+@prefix distribution: <http://data.lblod.info/id/distributions/> .
+@prefix service: <http://data.lblod.info/id/services/> .
 
 ##############################################################################
 # Publishers / contact points

--- a/config/migrations/add-decide-datasets/20260108152100-overview.ttl
+++ b/config/migrations/add-decide-datasets/20260108152100-overview.ttl
@@ -55,6 +55,38 @@ agent:945e9df0-c9e6-4f5c-a249-34075169e68d a foaf:Agent;
     vcard:hasEmail "loketlokaalbestuur@vlaanderen.be"
 .
 
+<http://data.lblod.info/id/catalogs/80fb699a-0d95-4089-843d-79c89138cdb7>
+    a dcat:Catalog;
+    mu:uuid "80fb699a-0d95-4089-843d-79c89138cdb7";
+    dct:title "DECIDe DCAT catalog";
+    dct:description "The catalog of datasets collected and used during the DECIDe project.";
+    dct:issued "2025-10-16"^^xsd:date;
+    dct:modified "2026-01-22"^^xsd:date;
+    dct:language <http://publications.europa.eu/resource/authority/language/ENG>;
+    foaf:homepage "https://www.vlaanderen.be/lokaal-bestuur/digitale-transformatie/slimme-lokale-databronnen/decide"^^xsd:anyURI;
+    dct:publisher agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
+    dcat:themeTaxonomy <https://vocab.belgif.be/auth/datatheme>;
+    dcat:dataset
+        dataset:2bb49e25-feb1-4daf-b98a-6c274e7d6d7d,
+        dataset:cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6,
+        dataset:0b2ad45a-eccf-45ac-874d-8b498a172772,
+        dataset:f7a4bbb3-1fef-4975-9049-ee933cfce30e,
+        dataset:74c12f17-f0eb-4bf2-8390-0d21655f00e3,
+        dataset:dd91b174-e9bb-4d33-8732-ed064a828b60,
+        dataset:2e1d52d9-2509-4b60-ac5a-0307897d64ef,
+        dataset:6aaa542d-410c-4150-bcfd-e5526eab87f4,
+        dataset:3d79b143-4009-451a-8b80-423da944d9a8,
+        dataset:6b65a734-7d22-4486-97e3-c7eafc7341d5,
+        dataset:38fd6817-f185-478d-9e21-12d6a694834c,
+        dataset:2ba4d174-e492-4bf2-b3a6-425f7afa51bf,
+        dataset:b0d10410-8bd0-408d-81d1-5794296e3e1b,
+        dataset:16a89d3f-b75d-4dc8-bee8-69089f734c27,
+        dataset:93951be6-e452-4579-807b-df5c969e333e,
+        dataset:ead64000-2c7d-4fcc-a255-fd1c3451f956,
+        dataset:3840171f-daf5-4efe-bf42-e7d511e6a1c1,
+        dataset:8a84f8a5-613a-45d0-bd43-e430dd3516ce
+.
+
 ##############################################################################
 # Lokaal Beslist
 

--- a/config/migrations/add-mock-data/20260122090000-delete-test-dcat-catalog-data.sparql
+++ b/config/migrations/add-mock-data/20260122090000-delete-test-dcat-catalog-data.sparql
@@ -1,0 +1,15 @@
+# Reversing config/migrations/add-mock-data/20251013113800-add-test-dcat-catalog-data.sparql
+WITH <http://mu.semte.ch/graphs/public> DELETE {?s ?p ?o} WHERE {
+  VALUES (?s) {
+    (<http://data.lblod.info/id/catalogs/5d39120a-9575-41aa-b098-a63d6df99e6b>)
+    (<http://mu.semte.ch/ext/resources/publishers/0a99b381-636b-41c7-b387-a0376c1495ad>)
+    (<http://mu.semte.ch/cms/resources/pages/6d1a64ad-c639-4452-8d24-4c5672c85623>)
+    (<http://data.lblod.info/id/formats/a6a5b899-35f3-4194-aad7-9e35448bf43d>)
+    (<http://data.lblod.info/id/agents/6887467a-f009-450d-8f03-df2e59f6e82c>)
+    (<http://data.lblod.info/id/concept-schemes/e8228abc-fce5-4f5e-82e6-7fba967a0d56>)
+    (<http://data.lblod.info/id/catalog-records/e77be476-7373-4b69-8373-719236acd16a>)
+    (<http://data.lblod.info/id/distributions/08a3c086-db07-458b-9a65-34064697503c>)
+    (<http://data.lblod.info/id/datasets/123e4567-e89b-12d3-a456-426614174000>)
+  }
+  ?s ?p ?o
+}

--- a/config/migrations/distribution-overview/20260108152100-overview.ttl
+++ b/config/migrations/distribution-overview/20260108152100-overview.ttl
@@ -1,0 +1,496 @@
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX cms: <http://mu.semte.ch/vocabulary/cms/>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dcatap: <http://data.europa.eu/r5r/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX eurovoc: <http://eurovoc.europa.eu/>
+PREFIX ex: <http://example.org/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ldes: <https://w3id.org/ldes#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX odrl: <https://www.w3.org/TR/odrl-vocab/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX agent: <http://data.lblod.info/id/agents/>
+PREFIX dataset: <http://data.lblod.info/id/datasets/>
+PREFIX distribution: <http://data.lblod.info/id/distributions/>
+PREFIX service: <http://data.lblod.info/id/services/>
+
+##############################################################################
+# Publishers / contact points
+
+agent:7365f73a-b57c-4999-aa8b-61464d9d3c6f a foaf:Agent;
+    vcard:hasEmail "zinfo@more-rubin.de";
+    vcard:hasName "more! software GmbH"
+.
+
+agent:658900ce-63cf-4d45-8fd5-a67ed8deab2c a foaf:Agent;
+    vcard:hasName "Municipality of Freiburg"@en
+.
+
+agent:c3c2a7bf-af3b-43b8-99f5-c3463ec9408a a foaf:Agent;
+    vcard:hasName "Vlaamse Overheid"@nl
+.
+
+agent:f45c1220-b250-4b93-8a8a-3e7e4a12a467 a foaf:Agent;
+    vcard:hasName "ABB Open Proces Huis"@nl
+.
+
+agent:436c5bce-8380-401e-8027-f34ef4acd97e a foaf:Agent;
+    vcard:hasName "ABB Lokaal Beslist"@nl
+.
+
+agent:7cb46783-0ca2-41a2-b28c-248b99e752e4 a foaf:Agent;
+    vcard:hasName "ABB DECIDe"@nl
+.
+
+agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb a foaf:Agent;
+    vcard:hasName "ABB DECIDe AI Team"@nl
+.
+
+agent:945e9df0-c9e6-4f5c-a249-34075169e68d a foaf:Agent;
+    vcard:hasName "Loket Lokaal Bestuur"@nl;
+    vcard:hasEmail "loketlokaalbestuur@vlaanderen.be"
+.
+
+##############################################################################
+# Lokaal Beslist
+
+dataset:2bb49e25-feb1-4daf-b98a-6c274e7d6d7d a dcat:Dataset;
+    mu:uuid "2bb49e25-feb1-4daf-b98a-6c274e7d6d7d";
+    dct:title "Lokaal Beslist Harvester 0";
+    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dct:publisher agent:;
+    dcat:contactPoint agent:436c5bce-8380-401e-8027-f34ef4acd97e;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+    dcat:distribution distribution:4697a3e9-9225-4ca1-a17c-0df585b4f872
+.
+distribution:4697a3e9-9225-4ca1-a17c-0df585b4f872 a dcat:Distribution;
+    mu:uuid "4697a3e9-9225-4ca1-a17c-0df585b4f872";
+    dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
+    dct:title "Lokaal Beslist SPARQL Endpoint 0";
+    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten";
+    dcat:accessURL "https://lokaalbeslist-harvester-0.s.redhost.be/sparql"^^xsd:anyURI;
+    dcat:accessService service:df87f118-165c-468d-b558-99f5c324d334;
+    dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
+.
+service:df87f118-165c-468d-b558-99f5c324d334 a dcat:DataService ;
+    mu:uuid "df87f118-165c-468d-b558-99f5c324d334";
+    dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
+    dcat:endpointURL "https://lokaalbeslist-harvester-0.s.redhost.be/sparql"^^xsd:anyURI ;
+    dcat:servesDataset dataset:2bb49e25-feb1-4daf-b98a-6c274e7d6d7d
+.
+
+dataset:cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6 a dcat:Dataset;
+    mu:uuid "cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6";
+    dct:title "Lokaal Beslist Harvester 1";
+    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dct:publisher agent:436c5bce-8380-401e-8027-f34ef4acd97e;
+    dcat:contactPoint agent:436c5bce-8380-401e-8027-f34ef4acd97e;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+    dcat:distribution distribution:3e9974a1-2182-404b-b60a-84a64468df31
+.
+distribution:3e9974a1-2182-404b-b60a-84a64468df31 a dcat:Distribution;
+    mu:uuid "3e9974a1-2182-404b-b60a-84a64468df31";
+    dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
+    dct:title "Lokaal Beslist SPARQL Endpoint 1";
+    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dcat:accessURL "https://lokaalbeslist-harvester-1.s.redhost.be/sparql"^^xsd:anyURI;
+    dcat:accessService service:57638b91-d88b-44cb-9664-61d108bb92e7;
+    dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
+.
+service:57638b91-d88b-44cb-9664-61d108bb92e7 a dcat:DataService ;
+    mu:uuid "57638b91-d88b-44cb-9664-61d108bb92e7";
+    dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
+    dcat:endpointURL "https://lokaalbeslist-harvester-1.s.redhost.be/sparql"^^xsd:anyURI ;
+    dcat:servesDataset dataset:cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6
+.
+
+dataset:0b2ad45a-eccf-45ac-874d-8b498a172772 a dcat:Dataset;
+    mu:uuid "0b2ad45a-eccf-45ac-874d-8b498a172772";
+    dct:title "Lokaal Beslist Harvester 2";
+    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dct:publisher agent:436c5bce-8380-401e-8027-f34ef4acd97e;
+    dcat:contactPoint agent:436c5bce-8380-401e-8027-f34ef4acd97e;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+    dcat:distribution distribution:e5f475b5-c6d3-4ff2-b8fc-0a81003138a0
+.
+distribution:e5f475b5-c6d3-4ff2-b8fc-0a81003138a0 a dcat:Distribution;
+    mu:uuid "e5f475b5-c6d3-4ff2-b8fc-0a81003138a0";
+    dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
+    dct:title "Lokaal Beslist SPARQL Endpoint 2";
+    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dcat:accessURL "https://lokaalbeslist-harvester-2.s.redhost.be/sparql"^^xsd:anyURI;
+    dcat:accessService service:706a5fda-ef6e-496e-a312-15a0620efe12;
+    dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
+.
+service:706a5fda-ef6e-496e-a312-15a0620efe12 a dcat:DataService ;
+    mu:uuid "706a5fda-ef6e-496e-a312-15a0620efe12";
+    dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
+    dcat:endpointURL "https://lokaalbeslist-harvester-2.s.redhost.be/sparql"^^xsd:anyURI ;
+    dcat:servesDataset dataset:0b2ad45a-eccf-45ac-874d-8b498a172772
+.
+
+dataset:f7a4bbb3-1fef-4975-9049-ee933cfce30e a dcat:Dataset;
+    mu:uuid "f7a4bbb3-1fef-4975-9049-ee933cfce30e";
+    dct:title "Lokaal Beslist Harvester 3";
+    dct:description "SPARQL endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dct:publisher agent:436c5bce-8380-401e-8027-f34ef4acd97e;
+    dcat:contactPoint agent:436c5bce-8380-401e-8027-f34ef4acd97e;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+    dcat:distribution distribution:19bada3c-fc39-4524-a692-d45e735f578f
+.
+distribution:19bada3c-fc39-4524-a692-d45e735f578f a dcat:Distribution;
+    mu:uuid "19bada3c-fc39-4524-a692-d45e735f578f";
+    dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
+    dct:title "Lokaal Beslist SPARQL Endpoint 3";
+    dct:description "Endpoint met lokale besluiten van Vlaamse gemeenten.";
+    dcat:accessURL "https://lokaalbeslist-harvester-3.s.redhost.be/sparql"^^xsd:anyURI;
+    dcat:accessService service:ec5feb51-9108-4c35-adef-d799f64bab9d;
+    dct:license <http://opendatacommons.org/licenses/pddl/1.0/>
+.
+service:ec5feb51-9108-4c35-adef-d799f64bab9d a dcat:DataService ;
+    mu:uuid "ec5feb51-9108-4c35-adef-d799f64bab9d";
+    dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
+    dcat:endpointURL "https://lokaalbeslist-harvester-3.s.redhost.be/sparql"^^xsd:anyURI ;
+    dcat:servesDataset dataset:f7a4bbb3-1fef-4975-9049-ee933cfce30e
+.
+
+##############################################################################
+# Open Proces Huis
+
+dataset:74c12f17-f0eb-4bf2-8390-0d21655f00e3 a dcat:Dataset;
+    mu:uuid "74c12f17-f0eb-4bf2-8390-0d21655f00e3";
+    dct:title "Open Proces Huis procesdata";
+    dct:description "Proces-, diagram- en invatarisdata van Open Proces Huis";
+    dct:publisher agent:f45c1220-b250-4b93-8a8a-3e7e4a12a467;
+    dcat:contactPoint agent:945e9df0-c9e6-4f5c-a249-34075169e68d;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
+    dct:distribution distribution:ad94e41e-a790-44bc-8602-e1fe0c7bc1b0
+.
+distribution:ad94e41e-a790-44bc-8602-e1fe0c7bc1b0 a dcat:Distribution;
+    mu:uuid "ad94e41e-a790-44bc-8602-e1fe0c7bc1b0";
+    dct:title "SPARQL endpoint";
+    dcat:accessURL "https://openproceshuis.vlaanderen.be/sparql";
+    dcat:accessService service:7333d62b-bd34-4063-ad34-28ec22a098b5
+.
+service:7333d62b-bd34-4063-ad34-28ec22a098b5 a dcat:DataService ;
+    mu:uuid "7333d62b-bd34-4063-ad34-28ec22a098b5";
+    dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
+    dcat:endpointURL "https://openproceshuis.vlaanderen.be/sparql"^^xsd:anyURI ;
+    dcat:servesDataset dataset:74c12f17-f0eb-4bf2-8390-0d21655f00e3
+.
+
+#############################################################################################################
+# AI datasets
+
+dataset:dd91b174-e9bb-4d33-8732-ed064a828b60 a dcat:Dataset;
+    mu:uuid "dd91b174-e9bb-4d33-8732-ed064a828b60";
+    dct:title "Ghent Municipal Decisions Roadblocks Classification";
+    dct:description "A comprehensive dataset of Dutch municipal decision documents from Ghent, Belgium, specifically processed and classified for traffic measures, roadblocks, and infrastructure projects that affect urban mobility.";
+    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/REGI>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+    dcat:distribution distribution:f27a58aa-5cbf-4612-b3d0-a4d49100153f
+.
+distribution:f27a58aa-5cbf-4612-b3d0-a4d49100153f a dcat:Distribution;
+    mu:uuid "f27a58aa-5cbf-4612-b3d0-a4d49100153f";
+    rdfs:comment "HuggingFace";
+    dct:format <http://publications.europa.eu/resource/authority/file-type/PARQUET>;
+    dct:title "Ghent Municipal Decisions Roadblocks Classification";
+    dct:description "HuggingFace data of Dutch municipal decision documents from Ghent, Belgium, specifically processed and classified for traffic measures, roadblocks, and infrastructure projects that affect urban mobility.";
+    dcat:accessURL "https://huggingface.co/datasets/svercoutere/abb-decide-ghent-roadblocks-classification"^^xsd:anyURI
+.
+
+dataset:2e1d52d9-2509-4b60-ac5a-0307897d64ef a dcat:Dataset;
+    mu:uuid "2e1d52d9-2509-4b60-ac5a-0307897d64ef";
+    dct:title "llama3 ABB Instruct";
+    dct:description "A comprehensive dataset to fine tune a llama3 model for translation, classification and keyword extraction from decision documents from Ghent";
+    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+    dcat:distribution distribution:4ed47dd1-aa35-4f94-b751-c0984349908c
+.
+distribution:4ed47dd1-aa35-4f94-b751-c0984349908c a dcat:Distribution;
+    mu:uuid "4ed47dd1-aa35-4f94-b751-c0984349908c";
+    rdfs:comment "HuggingFace";
+    dct:format <http://publications.europa.eu/resource/authority/file-type/PARQUET>;
+    dct:title "llama3 ABB Instruct";
+    dct:description "HuggingFace data to fine tune a llama3 model for translation, classification and keyword extraction from decision documents from Ghent";
+    dcat:accessURL "https://huggingface.co/datasets/svercoutere/llama3_abb_instruct_dataset"^^xsd:anyURI
+.
+
+dataset:6aaa542d-410c-4150-bcfd-e5526eab87f4 a dcat:Dataset;
+    mu:uuid "6aaa542d-410c-4150-bcfd-e5526eab87f4";
+    dct:title "ABB DECIDe SDGs Antwerp";
+    dct:description "A comprehensive dataset to classify decision documents from Antwerp into Sustainable Development Goals";
+    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/ENVI>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+    dcat:distribution distribution:6d5607a1-e1b3-4259-b186-760d8fef7da3
+.
+distribution:6d5607a1-e1b3-4259-b186-760d8fef7da3 a dcat:Distribution;
+    mu:uuid "6d5607a1-e1b3-4259-b186-760d8fef7da3";
+    rdfs:comment "HuggingFace";
+    dct:format <http://publications.europa.eu/resource/authority/file-type/PARQUET>;
+    dct:title "ABB DECIDe SDGs Antwerp";
+    dct:description "HuggingFace data to classify decision documents from Antwerp into Sustainable Development Goals";
+    dcat:accessURL "https://huggingface.co/datasets/svercoutere/abb-decide-sdgs-antwerp"^^xsd:anyURI
+.
+
+dataset:3d79b143-4009-451a-8b80-423da944d9a8 a dcat:Distribution;
+    mu:uuid "3d79b143-4009-451a-8b80-423da944d9a8";
+    dct:title "ABB DECIDe title extraction instruct";
+    dct:description "A comprehensive dataset to identify and extract the title from plain text decision documents from Ghent with the help of llama3";
+    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+    dcat:distribution distribution:b8b63c96-f5ce-496a-937e-7406f6aa1b91
+.
+distribution:b8b63c96-f5ce-496a-937e-7406f6aa1b91 a dcat:Distribution;
+    mu:uuid "b8b63c96-f5ce-496a-937e-7406f6aa1b91";
+    rdfs:comment "HuggingFace";
+    dct:format <http://publications.europa.eu/resource/authority/file-type/PARQUET>;
+    dct:title "ABB DECIDe title extraction instruct";
+    dct:description "HuggingFace data to identify and extract the title from plain text decision documents from Ghent with the help of llama3";
+    dcat:accessURL "https://huggingface.co/datasets/PedroDKE/ABB-DECIDe-title-extraction-instruct-dataset"^^xsd:anyURI
+.
+
+dataset:6b65a734-7d22-4486-97e3-c7eafc7341d5 a dcat:Dataset;
+    mu:uuid "6b65a734-7d22-4486-97e3-c7eafc7341d5";
+    dct:title "Flanders NER and Segmentation dataset";
+    dct:description "Labelstudio data to train segmentation and NER models on decision data from Flemish cities";
+    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
+    dcat:distribution distribution:a9233283-4233-41b0-a4e4-ab470c49a6f6
+.
+distribution:a9233283-4233-41b0-a4e4-ab470c49a6f6 a dcat:Distribution;
+    mu:uuid "a9233283-4233-41b0-a4e4-ab470c49a6f6";
+    rdfs:comment "Labelstudio";
+    dct:format <http://publications.europa.eu/resource/authority/file-type/OCTET>;
+    dct:title "Flanders NER and Segmentation dataset";
+    dct:description "Labelstudio data to train segmentation and NER models on decision data from Flemish cities";
+    dcat:accessURL "https://labelstudio.abb.ml2grow.cloud/projects/25/data?tab=73"^^xsd:anyURI
+.
+
+dataset:38fd6817-f185-478d-9e21-12d6a694834c a dcat:Dataset;
+    mu:uuid "38fd6817-f185-478d-9e21-12d6a694834c";
+    dct:title "Freiburg NER and Segmentation dataset";
+    dct:description "A comprehensive dataset to train segmentation and NER models on decision data from Freiburg";
+    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
+    dcat:distribution distribution:66b310c8-4d2b-4f8f-a292-c1882f939e6c
+.
+distribution:66b310c8-4d2b-4f8f-a292-c1882f939e6c a dcat:Distribution;
+    mu:uuid "66b310c8-4d2b-4f8f-a292-c1882f939e6c";
+    rdfs:comment "Labelstudio";
+    dct:format <http://publications.europa.eu/resource/authority/file-type/OCTET>;
+    dct:title "Freiburg NER and Segmentation dataset";
+    dct:description "Labelstudio data to train segmentation and NER models on decision data from Freiburg";
+    dcat:accessURL "https://labelstudio.abb.ml2grow.cloud/projects/26/data?tab=68"^^xsd:anyURI
+.
+
+dataset:2ba4d174-e492-4bf2-b3a6-425f7afa51bf a dcat:Dataset;
+    mu:uuid "2ba4d174-e492-4bf2-b3a6-425f7afa51bf";
+    dct:title "Bamberg NER and Segmentation dataset";
+    dct:description "A comprehensive dataset to train segmentation and NER models on decision data from Bamberg";
+    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
+    dcat:distribution distribution:7125af8b-f298-44a5-9c5f-c3db1b296fbd
+.
+distribution:7125af8b-f298-44a5-9c5f-c3db1b296fbd a dcat:Distribution;
+    mu:uuid "7125af8b-f298-44a5-9c5f-c3db1b296fbd";
+    rdfs:comment "Labelstudio";
+    dct:format <http://publications.europa.eu/resource/authority/file-type/OCTET>;
+    dct:title "Bamberg NER and Segmentation dataset";
+    dct:description "Labelstudio data to train segmentation and NER models on decision data from Bamberg";
+    dcat:accessURL "https://labelstudio.abb.ml2grow.cloud/projects/31/data?tab=110"^^xsd:anyURI
+.
+
+dataset:b0d10410-8bd0-408d-81d1-5794296e3e1b a dcat:Dataset;
+    mu:uuid "dataset:b0d10410-8bd0-408d-81d1-5794296e3e1b";
+    dct:title "Combined translated dataset";
+    dct:description "A comprehensive dataset to train segmentation and NER models on decision data from Bamberg, Freiburg and Ghent in English";
+    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
+    dcat:distribution distribution:ab53349d-155c-4ed4-ad5a-27404488b69b
+.
+distribution:ab53349d-155c-4ed4-ad5a-27404488b69b a dcat:Distribution;
+    mu:uuid "ab53349d-155c-4ed4-ad5a-27404488b69b";
+    rdfs:comment "Labelstudio";
+    dct:format <http://publications.europa.eu/resource/authority/file-type/OCTET>;
+    dct:title "Combined translated dataset";
+    dct:description "Labelstudio data to train segmentation and NER models on decision data from Bamberg, Freiburg and Ghent in English";
+    dcat:accessURL "https://labelstudio.abb.ml2grow.cloud/projects/27/data?tab=74"^^xsd:anyURI
+.
+
+
+##############################################################################
+# Besluitdata
+
+service:0993dd37-87d7-4c20-894b-f7e3ffc87b7c a dcat:DataService ;
+    mu:uuid "0993dd37-87d7-4c20-894b-f7e3ffc87b7c";
+    dct:title "Internal SPARQL endpoint";
+    dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/> ;
+    dcat:endpointURL "http://database:8890/sparql"^^xsd:anyURI ;
+    dcat:servesDataset
+        dataset:16a89d3f-b75d-4dc8-bee8-69089f734c27,
+        dataset:93951be6-e452-4579-807b-df5c969e333e,
+        dataset:ead64000-2c7d-4fcc-a255-fd1c3451f956
+.
+
+dataset:16a89d3f-b75d-4dc8-bee8-69089f734c27 a dcat:Dataset;
+    mu:uuid "16a89d3f-b75d-4dc8-bee8-69089f734c27";
+    dct:title "OSLO besluitdata";
+    dct:description "OSLO besluitdata geconsumeerd van Lokaal Beslists harvester 1. De data omvat agendapunten, behandelingen van agendapunten, besluiten, bestuursorganen, mandatarissen en stemmingen, en is onder andere afkomstig van alle Gentse bestuursorganen.";
+    dct:publisher agent:ABB;
+    dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
+    prov:alternateOf dataset:cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6;
+    dcat:distribution distribution:7ccb4d96-a5fe-466b-8d54-74dcd318db31
+.
+distribution:7ccb4d96-a5fe-466b-8d54-74dcd318db31 a dcat:Distribution;
+    mu:uuid "7ccb4d96-a5fe-466b-8d54-74dcd318db31";
+    dcat:accessURL "http://database:8890/sparqlD"^^xsd:anyURI;
+    dcat:accessService service:0993dd37-87d7-4c20-894b-f7e3ffc87b7c;
+    rdfs:comment "Dit is rechtstraaks overgenomen van Lokaal Beslist harvester 1. De graph is enkel bereikbaar door ons op onze server (niet-publiek), maar de orginele Lokaal Beslist data is publiek. Data is opgeslagen in een graph (http://mu.semte.ch/graphs/oslo-decisions/landing) in triplestore op onze dev server"
+.
+
+dataset:93951be6-e452-4579-807b-df5c969e333e a dcat:Dataset;
+    mu:uuid "93951be6-e452-4579-807b-df5c969e333e";
+    dct:title "ELI besluitdata Gent";
+    dct:description "ELI besluitdata gebaseerd op Gentse OSLO besluitdata in Lokaal Beslist";
+    dct:publisher agent:ABB;
+    dcat:contactPoint agent:7cb46783-0ca2-41a2-b28c-248b99e752e4;
+    dcat:theme <https://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
+    dcat:distribution distribution:c321d079-aa58-4732-a222-c3e9a76cdc8f
+.
+distribution:c321d079-aa58-4732-a222-c3e9a76cdc8f a dcat:Distribution;
+    mu:uuid "c321d079-aa58-4732-a222-c3e9a76cdc8f";
+    dcat:accessURL "http://database:8890/sparql"^^xsd:anyURI;
+    dcat:accessService service:0993dd37-87d7-4c20-894b-f7e3ffc87b7c;
+    rdfs:comment "Data is opgeslagen in een graph (http://mu.semte.ch/graphs/eli-decisions/ghent) in triplestore op onze dev server"
+.
+
+#################################################################################3
+# Freiburg
+
+dataset:ead64000-2c7d-4fcc-a255-fd1c3451f956 a dcat:Dataset;
+    mu:uuid "ead64000-2c7d-4fcc-a255-fd1c3451f956";
+    dct:title "Decisions from Freiburg"@en;
+    dct:description "Data that comes from the OParl API of Freiburg. This entails following OParl entities: System, Body, LegislativeTerm, Organization, Person, Membership, Meeting, AgendaItem, Paper, Consultation, File, Location"@en;
+    dct:publisher agent:658900ce-63cf-4d45-8fd5-a67ed8deab2c;
+    dcat:contactPoint agent:7365f73a-b57c-4999-aa8b-61464d9d3c6f;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+    dcat:distribution
+        distribution:33f42ce6-3278-438f-9463-37a9ab17b096,
+        distribution:743d147f-7079-4425-aa5b-0351dde216f4,
+        distribution:46321676-74d9-4ab9-be29-83612ab7ec51
+.
+distribution:33f42ce6-3278-438f-9463-37a9ab17b096 a dcat:Distribution;
+    mu:uuid "33f42ce6-3278-438f-9463-37a9ab17b096";
+    dct:title "SPARQL endpoint DEV Decide";
+    dct:description "SPARQL endpoint on the Dev server of Decide";
+    dcat:accessURL "http://database:8890/sparql"^^xsd:anyURI; # only internally available
+    dcat:accessService service:0993dd37-87d7-4c20-894b-f7e3ffc87b7c;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>
+.
+
+
+distribution:743d147f-7079-4425-aa5b-0351dde216f4 a dcat:Distribution;
+    mu:uuid "743d147f-7079-4425-aa5b-0351dde216f4";
+    dct:title "OParl-to-eli proxy (ELI)";
+    dct:description "Proxy API that provides OParl responses in ELI format on the fly";
+    dcat:accessURL "https://vc.decide-dev.s.redhost.be/eli/eli"^^xsd:anyURI;
+    dcat:accessService service:e27bea64-2c54-4dc0-8c6d-a6d4a1ed609b;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE>;
+    rdfs:comment "REST (HTTP + Turtle)"
+.
+service:e27bea64-2c54-4dc0-8c6d-a6d4a1ed609b a dcat:DataService ;
+    mu:uuid "e27bea64-2c54-4dc0-8c6d-a6d4a1ed609b";
+    dcat:endpointURL "https://vc.decide-dev.s.redhost.be/eli/eli"^^xsd:anyURI ;
+    dcat:servesDataset dataset:ead64000-2c7d-4fcc-a255-fd1c3451f956
+.
+
+distribution:46321676-74d9-4ab9-be29-83612ab7ec51 a dcat:Distribution;
+    mu:uuid "46321676-74d9-4ab9-be29-83612ab7ec51";
+    dct:title "OParl API Freiburg"@en;
+    dct:description "OParl API is a JSON API offered by the vendor of Freiburg. The OParl specification can be found here: https://oparl.org/spezifikation/"@en;
+    dcat:accessURL "https://ris.freiburg.de/oparl"^^xsd:anyURI;
+    dcat:accessService service:a04a2727-d097-4297-93cc-1b3bfe7bf5e2;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/JSON>;
+    rdfs:comment "REST (HTTP + JSON)"
+.
+service:a04a2727-d097-4297-93cc-1b3bfe7bf5e2 a dcat:DataService ;
+    mu:uuid "a04a2727-d097-4297-93cc-1b3bfe7bf5e2";
+    dct:conformsTo <https://oparl.org/spezifikation/> ;
+    dcat:endpointURL "https://ris.freiburg.de/oparl"^^xsd:anyURI ;
+    dcat:servesDataset dataset:ead64000-2c7d-4fcc-a255-fd1c3451f956
+.
+
+##############################################################################
+# Source document datasets for annotation
+
+dataset:3840171f-daf5-4efe-bf42-e7d511e6a1c1 a dcat:Dataset;
+    mu:uuid "3840171f-daf5-4efe-bf42-e7d511e6a1c1";
+    dct:title "Freiburg local decisions"@en;
+    dct:description "The data for Freiburg is retrieved from the city's public meeting API (https://ris.freiburg.de/oparl/). It first requests page 1 to determine the total number of meeting pages, then iterates through all pages to collect agenda items from each meeting. For each agenda item with a resolutionFile, it downloads the file, verifies that the content is a real PDF, and saves it locally with a unique filename. "@en;
+    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
+    rdfs:seeAlso "https://app.gitbook.com/o/-MP9Yduzf5xu7wIebqPG/s/grRYjcouX0uZY2P6PYBl/ai-analysis-research/ai-approach-uc-0.0/named-entity-recognition"^^xsd:anyURI;
+    dcat:distribution distribution:db4e1b76-1a09-45fa-99be-32ddc5840a37
+.
+distribution:db4e1b76-1a09-45fa-99be-32ddc5840a37 a dcat:Distribution;
+    mu:uuid "db4e1b76-1a09-45fa-99be-32ddc5840a37";
+    dct:title "Freiburg PDFs on local decisions"@en;
+    dct:description "Freiburg PDFs on local decisions"@en;
+    rdfs:comment "Only internally available."@en;
+    dcat:accessURL "https://u486391-sub1.your-storagebox.de/home/datasets/freiburg/freiburg_pdfs"^^xsd:anyURI;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/PDF>
+.
+
+dataset:8a84f8a5-613a-45d0-bd43-e430dd3516ce a dcat:Dataset;
+    mu:uuid "8a84f8a5-613a-45d0-bd43-e430dd3516ce";
+    dct:title "Bamberg local decisions"@en;
+    dct:description "The Bamberg data is scraped from the city's decision consultation website (https://www.stadt.bamberg.de/buergerinformationssystem/) by iterating through a large range of possible volfdnrs. Multiple workers run in parallel to probe each volfdnr, extract structured page content when a valid record exists, and write results to JSONL files. After scraping, all worker outputs are merged into a single deduplicated dataset. For entries that include a “Vorlage” PDF, the script must first open the item’s resolutionUrl to obtain a valid session cookie, because the PDF links provided by the Bamberg Bürgerinformationssystem are Wicket resource URLs that only work with an active session. "@en;
+    dct:publisher agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:contactPoint agent:bcdaccd2-5651-4c1d-8021-415a43ee4cfb;
+    dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
+    dct:accessRights <http://publications.europa.eu/resource/authority/access-right/RESTRICTED>;
+    dcat:distribution distribution:7661627c-3cae-4991-bbdc-1f0a3f633781
+
+.
+distribution:7661627c-3cae-4991-bbdc-1f0a3f633781 a dcat:Distribution;
+    mu:uuid "7661627c-3cae-4991-bbdc-1f0a3f633781";
+    dct:title "Bamberg PDFs on local decisions";
+    dct:description "Bamberg PDFs on local decisions.";
+    dcat:accessURL "https://u486391-sub1.your-storagebox.de/home/datasets/bamberg/bamberg_pdfs"^^xsd:anyURI; # only internally available
+    dct:format <http://publications.europa.eu/resource/authority/file-type/PDF>
+.


### PR DESCRIPTION
References:

- https://binnenland.atlassian.net/browse/LBRON-339
- https://binnenland.atlassian.net/browse/LBRON-879

These tickets both refer to DCAT descriptions, so they are taken together in this PR. As discussed with @Rahien , I have additionally included the other datasets collected on GitBook.

In absence of https://binnenland.atlassian.net/browse/LBRON-875, I have passed these through OSLO Application Profile's SHACL validation, which can be found here: https://data.vlaanderen.be/doc/applicatieprofiel/metadata-dcat/erkendestandaard/2022-04-21/

However, this leads to a lot of violations, some of which can be ignored. In particular, the reasoning is as follows:

- It demands that `dct:format` is drawn from <https://publications.europa.eu/resource/authority/file-type>, but the canonical URLs use the HTTP scheme, not HTTPS.
- OSLO would like us to draw `dct:conformsTo` from <https://data.vlaanderen.be/id/conceptscheme/dataserviceprotocol> but if we did that, we wouldn't be able to describe OParl; <http://publications.europa.eu/resource/authority/file-type> seems more applicable to an European context anyway.
- It complains that we have not set a `dcat:downloadURL` and `dc:identifier`, which is not required.
- I am used to link to external web pages (that shouldn't be interpreted as RDF resources) as literal with data type `xsd:anyURI`, instead of as URI resource. These shapes reject that, which suggests that this is not a convention that we follow within ABB. Is that the case?