### PR TITLE
fix: link `oa:SpecificResource` to `eli:Expression` instead of `eli:Work`

### DIFF
--- a/config/migrations/20251212094726-insert-example-geo-data/20260123091934-fix--link-specific-resources-to-expressions.sparql
+++ b/config/migrations/20251212094726-insert-example-geo-data/20260123091934-fix--link-specific-resources-to-expressions.sparql
@@ -1,0 +1,22 @@
+PREFIX oa: <http://www.w3.org/ns/oa#>
+PREFIX skolem: <http://www.example.org/id/.well-known/genid/>
+
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Polygon
+    skolem:c53ae985-0952-4b41-877a-a68039159645 oa:source <http://data.lblod.info/id/works/d49f434b-94d3-4d41-913d-e25f2649ab52> .
+    # Polyline
+    skolem:a2f783aa-5146-4d7d-8386-3cc038b9f292 oa:source <http://data.lblod.info/id/works/83dd62dd-67cf-414a-9843-3ca484bce207> .
+    # Point
+    skolem:partOfText oa:source <http://data.lblod.info/id/works/exampleWork> .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    # Polygon
+    skolem:c53ae985-0952-4b41-877a-a68039159645 oa:source <http://data.lblod.info/id/expressions/c0a9fc3b-ea9a-4b7b-8e20-84b9f18c7f4b> .
+    # Polyline
+    skolem:a2f783aa-5146-4d7d-8386-3cc038b9f292 oa:source <http://data.lblod.info/id/expressions/72bd3baf-7ca4-4c12-954d-91b05964e6ee> .
+    # Point
+    skolem:partOfText oa:source <http://data.lblod.info/id/expressions/exampleExpression> .
+  }
+}

--- a/config/resources/annotation.lisp
+++ b/config/resources/annotation.lisp
@@ -14,8 +14,8 @@
 
 (define-resource specific-resource ()
   :class (s-prefix "oa:SpecificResource")
-  :has-one `((work :via ,(s-prefix "oa:source")
-                   :as "source")
+  :has-one `((expression :via ,(s-prefix "oa:source")
+                         :as "source")
              (text-position-selector :via ,(s-prefix "oa:selector")
                                      :as "selector"))
   :resource-base (s-url "http://data.lblod.info/id/specific-resource/")


### PR DESCRIPTION
The source to which `oa:SpecificResource`s refers is typically found in a
`eli:Expression` resource, not in the `eli:Work` resource associated with
this. Therefore, we should link to the former instead of the latter.

This PR also updates the example data added in #32 accordingly.