### PR TITLE
fix(migrations): remove triple with xsd:duration object

### DIFF
--- a/config/migrations/add-mock-data/20251013113800-add-test-dcat-catalog-data.sparql
+++ b/config/migrations/add-mock-data/20251013113800-add-test-dcat-catalog-data.sparql
@@ -195,7 +195,6 @@ INSERT DATA {
       # optionals we likely won't use
       ################################
       dcat:qualifiedRelation ex:relation-001 ;
-      dcat:temporalResolution "P1Y"^^xsd:duration ;
       dcat:spatialResolutionInMeters 1 ;
       foaf:page ex:foaf-document-001
     .


### PR DESCRIPTION
Virtuoso sometimes throws an error when inserting this particular triple:

```
Virtuoso 22023 Error SR553: Literal of type xsd:duration can not be created from
SQL value of type ARRAY_OF_DOUBLE (195): SR066: Unsupported case in
CONVERT (ARRAY_OF_DOUBLE -> UNK_DV_TYPE) (SPARQL::Client::ServerError)
```

This only occurs on some instances of virtuoso, but does block executing the
migration on those. Therefore we opted to remove this triple from the migration
altogether. This migration adds mock data that was already removed again in
#37. So this is mainly to prevent that people run into this error when setting
up new instances of the app.