### PR TITLE
Add bestuursorgaan tijdspecialisaties

### DIFF
--- a/config/migrations/bestuurseenheden-and-organizations-flanders/20260210101400-add-tijdspecialisaties.graph
+++ b/config/migrations/bestuurseenheden-and-organizations-flanders/20260210101400-add-tijdspecialisaties.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/bestuurseenheden-bestuursorganen


### PR DESCRIPTION
It turns out the OSLO-ELI transformation step should take into account time specializations of bestuursorganen. Since the necessary predicate `mandaat:isTijdspecialisatieVan` is not present in the consumed data from Lokaal Beslist (or at least not on all time bestuursorganen), this is added with this migration.