### PR TITLE
feat: configuration for ACM/IDM authentication

### DIFF
--- a/config/authorization/decide.lisp
+++ b/config/authorization/decide.lisp
@@ -1,6 +1,7 @@
 (in-package :acl)
 
 (define-prefixes
+  :adms "http://www.w3.org/ns/adms#"
   :besluit "http://data.vlaanderen.be/ns/besluit#"
   :cms "http://mu.semte.ch/vocabulary/cms/"
   :cogs "http://vocab.deri.ie/cogs#"
@@ -129,6 +130,11 @@
   ("tasks:CronSchedule" -> _ )
   ("schema:repeatFrequency" -> _ ))
 
+(define-graph organization ("http://mu.semte.ch/graphs/organizations/")
+  ("foaf:Person" -> _)
+  ("foaf:OnlineAccount" -> _)
+  ("adms:Identifier" -> _))
+
 (supply-allowed-group "public")
 
 (grant (read)
@@ -156,3 +162,15 @@
       SELECT DISTINCT ?account WHERE {
       <SESSION_ID> session:account ?account.
       }")
+
+(supply-allowed-group "organization-member"
+  :parameters ("session_group")
+  :query "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+          PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+          SELECT ?session_group ?session_role WHERE {
+            <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group.
+          }")
+
+(grant (read)
+       :to-graph organization
+       :for-allowed-group "organization-member")

--- a/config/authorization/decide.lisp
+++ b/config/authorization/decide.lisp
@@ -174,3 +174,14 @@
 (grant (read)
        :to-graph organization
        :for-allowed-group "organization-member")
+
+;; TODO: Is this supposed to be the final graph?
+;; NOTE (10/02/2026): Graphs <http://mu.semte.ch/graphs/organizations> does NOT contain the
+;; `besluit:Bestuurseenheid' type (only `org:Organization'), used that one causes resource service
+;; to bug out
+(define-graph organizations ("http://mu.semte.ch/graphs/bestuurseenheden-bestuursorganen")
+  ("besluit:Bestuurseenheid" -> _))
+
+(grant (read)
+       :to-graph organizations
+       :for-allowed-group "public")

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -10,7 +10,7 @@ defmodule Dispatcher do
 
   define_layers([:static, :sparql, :api_services, :frontend_fallback, :resources, :not_found])
 
-  options "/*path", _ do
+  options "/*_path", _ do
     conn
     |> Plug.Conn.put_resp_header("access-control-allow-headers", "content-type,accept")
     |> Plug.Conn.put_resp_header("access-control-allow-methods", "*")
@@ -348,12 +348,12 @@ defmodule Dispatcher do
   #################
 
   # self-service
-  match "/*path", %{reverse_host: ["dashboard" | _rest], accept: %{html: true}} do
+  match "/*_path", %{reverse_host: ["dashboard" | _rest], accept: %{html: true}} do
     # we don't forward the path, because the app should take care of this in the browser.
     forward(conn, [], "http://frontend-harvesting/index.html")
   end
 
-  match "/*path", %{layer: :frontend_fallback, accept: %{html: true}} do
+  match "/*_path", %{layer: :frontend_fallback, accept: %{html: true}} do
     # we don't forward the path, because the app should take care of this in the browser.
     forward(conn, [], "http://frontend/index.html")
   end

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -306,7 +306,7 @@ defmodule Dispatcher do
   end
 
   match "/sessions/*path", %{layer: :api_services, accept: %{any: true}} do
-    Proxy.forward(conn, path, "http://login/sessions/")
+    Proxy.forward(conn, path, "http://acmidm-login/sessions/")
   end
 
   match "/mock/sessions/*path", %{layer: :api_services, accept: %{any: true} } do

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -313,7 +313,7 @@ defmodule Dispatcher do
     Proxy.forward(conn, path, "http://mocklogin/sessions/")
   end
 
-###############
+  ###############
   # STATIC
   ###############
 

--- a/config/sink/sink.conf
+++ b/config/sink/sink.conf
@@ -1,0 +1,7 @@
+server {
+  error_page 404 =200 @empty_json;
+
+  location @empty_json {
+    return 200 "{}";
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,12 +85,16 @@ services:
   acmidm-login:
     image: lblod/acmidm-login-service:0.12.0
     environment:
-      MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie-ti.vlaanderen.be/op"
-      MU_APPLICATION_AUTH_CLIENT_ID: "temp"
       LOG_SINK_URL: "http://sink"
       MU_APPLICATION_AUTH_JWK_PRIVATE_KEY: /config/jwk_private_key.json
       MU_APPLICATION_AUTH_USERID_CLAIM: vo_id
-      MU_APPLICATION_AUTH_REDIRECT_URI: "https://ds.decide.lblod.info/authorization/callback"
+      MU_APPLICATION_AUTH_ROLE_CLAIM: "abb_decide_rol_3d"
+      MU_APPLICATION_GRAPH: "http://mu.semte.ch/graphs/bestuurseenheden-bestuursorganen"
+      # The following are environment-specific and should be set in the
+      # environment's appropriate override file.
+      MU_APPLICATION_AUTH_CLIENT_ID: "<AUTH_CLIENT_ID>"
+      MU_APPLICATION_AUTH_DISCOVERY_URL: "<AUTH_DISCOVERY_URL>"
+      MU_APPLICATION_AUTH_REDIRECT_URI: "<AUTH_REDIRECT_URI>"
     volumes:
       - ./config/login:/config
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,14 @@ services:
     logging: *default-logging
     labels:
       - "logging=true"
+  sink:
+    image: nginx:1.15.2
+    volumes:
+      - ./config/sink/sink.conf:/etc/nginx/conf.d/default.conf
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
 
   ##############################################################################
   # DATA SPACE


### PR DESCRIPTION
This PR configures the DECIDe app for integration with the ACM/IDM authentication flow.

## Proposed changes
### Dispatcher
Update service's last `sessions` route to forward to the `acmidm-login` service instead of the `login` service. The latter should only be used for the plain username/password login used for the dashboard, which is captured by rules earlier in the configuration.

### Sparql-parser
Define additional access rights necessary for the frontend to properly handle authentication and retrieving user information.

The `http://mu.semte.ch/graphs/organizations/UUID` graphs contain account information for users associated with that particular organisation. The frontend queries for the account belonging to a session when it tries to load the data for the current session. A user only gets read access to the organisation's graph its account is associated with.

Similarly, the `http://mu.semte.ch/graphs/bestuurseenheden-bestuursorganen` graph contains data on administrative units. The frontend will also query for this when loading a current session. As this should only contain public data I opted to grant public read access to this graph.

### Add sink service
Add a `sink` service, this service was already configure as `LOG_SINK_URL` for the `acmidm-login` service. But because the service was never actually added to the stack this caused the `acmidm-login` service to crash when it tried to contact it. The `sink` service allow `app-http-logger` to log more complete information.

## Related PRs
- [Frontend PR](https://github.com/lblod/frontend-decide/pull/13)

## Related tickets
- LBRON-838