### PR TITLE
chore: add frontend to stack

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,6 +38,8 @@ services:
     restart: "no"
   deltanotifier:
     restart: "no"
+  frontend:
+    restart: "no"
   frontend-harvesting:
     restart: "no"
   oparl-to-eli:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,12 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  frontend:
+    image: lblod/frontend-decide:0.0.2
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
 
   ##############################################################################
   # DATA SPACE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,14 @@ services:
     logging: *default-logging
   frontend:
     image: lblod/frontend-decide:0.0.2
+    environment:
+      # The following are environment-specific and should be set in the
+      # environment's appropriate override file.
+      EMBER_OAUTH_API_KEY: "<OAUTH_API_KEY>"
+      EMBER_OAUTH_API_REDIRECT_URL: "<OAUTH_API_REDIRECT_URL>"
+      EMBER_OAUTH_API_BASE_URL: "<OAUTH_API_BASE_URL>"
+      EMBER_OAUTH_API_LOGOUT_URL: "<OAUTH_API_LOGOUT_URL"
+      EMBER_OAUTH_API_SCOPE: "<OAUTH_API_SCOPE>"
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
Explicitly adds the frontend to the stack using a tagged build to improve
reproducability. Note the environment variables for ACM/IDM will be configured
for each environment in its own override.