### PR TITLE
Open SPARQL endpoint.

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -65,6 +65,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://question-answering/uc2/"
   end
 
+  match "/api/sparql", %{ accept: [:any], layer: :api_services } do
+    Proxy.forward conn, [], "http://database:8890/sparql"
+  end
+
   #################
   # Jobs & tasks
   #################


### PR DESCRIPTION
This commit opens the SPARQL endpoint and adds a corresponding route to the dispatcher. It is needed for a frontend SPARQL endpoint interface.