### PR TITLE
Split frontends.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,15 +105,6 @@ To show how decisions are linked with SDGs, a Policy impact report tool is being
 
 ## Pipeline dashboard
 
-### Accessing the dashboard from your local machine
-
-Since we use dispatcher v2, which dispatches on hostname, we'll have to update `/etc/hosts`.
-Add an entry similar to the following. Ensure the first part of the domain starts with `dashboard`.:
-
-```
-127.0.0.1 dashboard.localhost
-```
-
 ### Jobs
 
 There are two types of jobs: harvesting and scheduled. The harvesting job is a one-time run of a job, while the scheduled job is triggered periodically following a cron pattern.
@@ -121,3 +112,16 @@ There are two types of jobs: harvesting and scheduled. The harvesting job is a o
 By pressing "Create new job", a job type ("operation") can be selected to create a new job.
 
 ![alt text](doc/dashboard-create-new-2.png)
+
+## Frontends
+
+### Accessing the frontends from your local machine
+
+We use dispatcher v2, which dispatches different frontends based on hostname. If this does not work out of the box, you may have to add an entry similar to the following to your `/etc/hosts`:
+
+```
+127.0.0.1 dashboard.localhost
+127.0.0.1 dcat.localhost
+127.0.0.1 human-validator.localhost
+127.0.0.1 yasgui.localhost
+```

--- a/compose/base-compose.yml
+++ b/compose/base-compose.yml
@@ -89,8 +89,8 @@ services:
       - 'logging=true'
     restart: always
     logging: *default-logging
-  frontend:
-    image: lblod/frontend-decide:0.0.3
+  frontend-yasgui:
+    image: lblod/frontend-decide-yasgui:0.0.4
     environment:
       # The following are environment-specific and should be set in the
       # environment's appropriate override file.
@@ -99,6 +99,18 @@ services:
       EMBER_OAUTH_API_BASE_URL: '<OAUTH_API_BASE_URL>'
       EMBER_OAUTH_API_LOGOUT_URL: '<OAUTH_API_LOGOUT_URL'
       EMBER_OAUTH_API_SCOPE: '<OAUTH_API_SCOPE>'
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+  frontend-human-validator:
+    image: lblod/frontend-decide-human-validator:0.0.4
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+  frontend-dcat:
+    image: lblod/frontend-decide-dcat:0.0.4
     labels:
       - 'logging=true'
     restart: always

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -65,6 +65,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://question-answering/uc2/"
   end
 
+  match "/api/sparql", %{ accept: [:any], layer: :api_services, reverse_host: ["yasgui" | _rest]} do
+    Proxy.forward conn, [], "http://database:8890/sparql"
+  end
+
   match "/api/sparql", %{ accept: [:any], layer: :api_services } do
     Proxy.forward conn, [], "http://database:8890/sparql"
   end
@@ -313,6 +317,14 @@ defmodule Dispatcher do
     Proxy.forward(conn, path, "http://mocklogin/sessions/")
   end
 
+  match "/sessions/*path", %{reverse_host: ["yasgui" | _rest]} do
+    Proxy.forward(conn, path, "http://login/sessions/")
+  end
+
+  match "/mock/sessions/*path", %{reverse_host: ["yasgui" | _rest]} do
+    Proxy.forward(conn, path, "http://mocklogin/sessions/")
+  end
+
   match "/sessions/*path", %{layer: :api_services, accept: %{any: true}} do
     Proxy.forward(conn, path, "http://acmidm-login/sessions/")
   end
@@ -338,32 +350,70 @@ defmodule Dispatcher do
     forward(conn, path, "http://frontend-harvesting/@appuniversum/")
   end
 
-  match "/index.html", %{layer: :static} do
-    forward(conn, [], "http://frontend/index.html")
+  # dcat
+  match "/index.html",  %{reverse_host: ["dcat" | _rest], layer: :static} do
+    forward(conn, [], "http://frontend-dcat/index.html")
   end
 
-  get "/assets/*path", %{layer: :static} do
-    forward(conn, path, "http://frontend/assets/")
+  get "/assets/*path", %{reverse_host: ["dcat" | _rest], layer: :static} do
+    forward(conn, path, "http://frontend-dcat/assets/")
   end
 
-  get "/@appuniversum/*path", %{layer: :static} do
-    forward(conn, path, "http://frontend/@appuniversum/")
+  get "/@appuniversum/*path",  %{reverse_host: ["dcat" | _rest], layer: :static} do
+    forward(conn, path, "http://frontend-dcat/@appuniversum/")
   end
 
+  # human validator
+  match "/index.html",  %{reverse_host: ["human-validator" | _rest], layer: :static} do
+    forward(conn, [], "http://frontend-human-validator/index.html")
+  end
+
+  get "/assets/*path", %{reverse_host: ["human-validator" | _rest], layer: :static} do
+    forward(conn, path, "http://frontend-human-validator/assets/")
+  end
+
+  get "/@appuniversum/*path",  %{reverse_host: ["human-validator" | _rest], layer: :static} do
+    forward(conn, path, "http://frontend-human-validator/@appuniversum/")
+  end
+
+  # yasgui
+  match "/index.html",  %{reverse_host: ["yasgui" | _rest], layer: :static} do
+    forward(conn, [], "http://frontend-yasgui/index.html")
+  end
+
+  get "/assets/*path", %{reverse_host: ["yasgui" | _rest], layer: :static} do
+    forward(conn, path, "http://frontend-yasgui/assets/")
+  end
+
+  get "/@appuniversum/*path",  %{reverse_host: ["yasgui" | _rest], layer: :static} do
+    forward(conn, path, "http://frontend-yasgui/@appuniversum/")
+  end
 
   #################
   # FRONTEND PAGES
   #################
 
+  # we don't forward the path, because the app should take care of this in the browser.
+
   # self-service
   match "/*_path", %{reverse_host: ["dashboard" | _rest], accept: %{html: true}} do
-    # we don't forward the path, because the app should take care of this in the browser.
     forward(conn, [], "http://frontend-harvesting/index.html")
   end
 
+  match "/*_path", %{reverse_host: ["dcat" | _rest], accept: %{html: true}} do
+    forward(conn, [], "http://frontend-dcat/index.html")
+  end
+
+  match "/*_path", %{reverse_host: ["human-validator" | _rest], accept: %{html: true}} do
+    forward(conn, [], "http://frontend-human-validator/index.html")
+  end
+
+  match "/*_path", %{reverse_host: ["yasgui" | _rest], accept: %{html: true}} do
+    forward(conn, [], "http://frontend-yasgui/index.html")
+  end
+
   match "/*_path", %{layer: :frontend_fallback, accept: %{html: true}} do
-    # we don't forward the path, because the app should take care of this in the browser.
-    forward(conn, [], "http://frontend/index.html")
+    forward(conn, [], "http://frontend-dcat/index.html")
   end
 
   #################

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -8,7 +8,7 @@ defmodule Dispatcher do
     any: ["*/*"]
   ]
 
-  define_layers([:static, :sparql, :api_services, :frontend_fallback, :resources, :not_found])
+  define_layers([:static, :sparql, :frontend, :api_services, :frontend_fallback, :resources, :not_found])
 
   options "/*_path", _ do
     conn
@@ -65,11 +65,7 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://question-answering/uc2/"
   end
 
-  match "/api/sparql", %{ accept: [:any], layer: :api_services, reverse_host: ["yasgui" | _rest]} do
-    Proxy.forward conn, [], "http://database:8890/sparql"
-  end
-
-  match "/api/sparql", %{ accept: [:any], layer: :api_services } do
+  match "/api/sparql", %{ reverse_host: ["yasgui" | _rest], accept: [:any], layer: :sparql } do
     Proxy.forward conn, [], "http://database:8890/sparql"
   end
 
@@ -396,19 +392,19 @@ defmodule Dispatcher do
   # we don't forward the path, because the app should take care of this in the browser.
 
   # self-service
-  match "/*_path", %{reverse_host: ["dashboard" | _rest], accept: %{html: true}} do
+  match "/*_path", %{reverse_host: ["dashboard" | _rest], accept: %{html: true}, layer: :frontend } do
     forward(conn, [], "http://frontend-harvesting/index.html")
   end
 
-  match "/*_path", %{reverse_host: ["dcat" | _rest], accept: %{html: true}} do
+  match "/*_path", %{reverse_host: ["dcat" | _rest], accept: %{html: true}, layer: :frontend} do
     forward(conn, [], "http://frontend-dcat/index.html")
   end
 
-  match "/*_path", %{reverse_host: ["human-validator" | _rest], accept: %{html: true}} do
+  match "/*_path", %{reverse_host: ["human-validator" | _rest], accept: %{html: true}, layer: :frontend} do
     forward(conn, [], "http://frontend-human-validator/index.html")
   end
 
-  match "/*_path", %{reverse_host: ["yasgui" | _rest], accept: %{html: true}} do
+  match "/*_path", %{reverse_host: ["yasgui" | _rest], accept: %{html: true}, layer: :frontend } do
     forward(conn, [], "http://frontend-yasgui/index.html")
   end
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,7 +38,11 @@ services:
     restart: "no"
   deltanotifier:
     restart: "no"
-  frontend:
+  frontend-yasgui:
+    restart: "no"
+  frontend-dcat:
+    restart: "no"
+  frontend-human-validator:
     restart: "no"
   frontend-harvesting:
     restart: "no"


### PR DESCRIPTION
A split has been made between the different front-ends:

- https://github.com/lblod/frontend-decide-dcat for the DCAT catalogue
- https://github.com/lblod/frontend-decide-yasgui for the SPARQL interface and necessary VC authorization
- https://github.com/lblod/frontend-decide-human-validator for the AI annotations

# Note on frontend PRs

This is the PR for the backend, and the changes are minimal. 

At the front-end, while figuring out how to pull versioned images for Woodpecker, I had already caught up the new repositories to `master`. The repositories are simply forks of https://github.com/lblod/frontend-decide (in the sense that I initially created them by simply adding extra remotes to that original repo). However, GitHub won't recognize them as forks that way.

I realize that makes the front-ends a bit harder to review. Apologies for that. All changes are relative to https://github.com/lblod/frontend-decide/commit/80806d0baeda3c620e479ff5fea2256e19e86e31. Would it help the review process to create 'mock' frontend PRs against `80806d0...`?