### PR TITLE
description of how to prune oslo data after initial load

### DIFF
--- a/OSLO_PRUNING.md
+++ b/OSLO_PRUNING.md
@@ -1,0 +1,133 @@
+The OSLO configuration depends on consuming all data from a full LBLOD harvester. This results in a lot of extra data that is not necessary, only the Ghent decisions are used in Decide.
+
+The following queries allow you to remove most of the unnecessary data and trim the db to a manageable size
+
+The queries will remove non-ghent decisions (easily identifiable because they are not in the ghent target graph after the oslo pipeline has run) and then proceed to progressively remove unlinked items.
+
+## remove non-ghent decisions
+
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+    DELETE {
+      GRAPH <http://mu.semte.ch/graphs/oslo-decisions/landing> {
+        ?s ?p ?o.
+      }
+    }WHERE {
+      GRAPH <http://mu.semte.ch/graphs/oslo-decisions/landing> {
+        ?s a besluit:Besluit.
+        ?s ?p ?o.
+      }
+      FILTER NOT EXISTS {
+        GRAPH <http://mu.semte.ch/graphs/public/gent> {
+          ?s a <http://data.europa.eu/eli/ontology#Expression>
+        }
+      }
+    }
+
+## remove behandelingen that are not useful
+
+    DELETE {
+      GRAPH ?g {
+        ?s ?p ?o.
+      }
+    }
+    WHERE {
+      GRAPH ?g {
+        ?s a <http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt>.
+        ?s ?p ?o.
+        FILTER NOT EXISTS {
+          ?besluit <http://www.w3.org/ns/prov#wasGeneratedBy> ?s.
+        }
+      }
+    }
+
+## remove agendapunten without behandeling
+
+    DELETE {
+      GRAPH ?g {
+        ?s ?p ?o.
+      }
+    }WHERE {
+      GRAPH ?g {
+        ?s a <http://data.vlaanderen.be/ns/besluit#Agendapunt>.
+        ?s ?p ?o.
+
+        FILTER NOT EXISTS {
+          ?behandeling <http://data.vlaanderen.be/ns/besluit#behandelt> ?s.
+          ?behandeling a <http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt>.
+        }
+      }
+    }
+
+## remove artikels
+
+    DELETE {
+      GRAPH ?g {
+        ?s ?p ?o.
+      }
+    }WHERE {
+      GRAPH ?g {
+        ?s a <http://data.vlaanderen.be/ns/besluit#Artikel>.
+        ?s ?p ?o.
+        FILTER NOT EXISTS {
+          ?besluit <http://data.europa.eu/eli/ontology#has_part> ?s.
+        }
+      }
+    }
+
+## remove stemming
+
+    DELETE {
+      GRAPH ?g {
+        ?s ?p ?o.
+      }
+    }WHERE {
+      GRAPH ?g {
+        ?s a <http://data.vlaanderen.be/ns/besluit#Stemming> .
+        ?s ?p ?o.
+        FILTER NOT EXISTS {
+          ?agendapunt <http://data.vlaanderen.be/ns/besluit#heeftStemming> ?s.
+          ?agendapunt a ?thing.
+        }
+      }
+    }
+
+## remove zittingen
+
+    DELETE {
+      GRAPH ?g {
+        ?s ?p ?o.
+      }
+    }WHERE {
+      GRAPH ?g {
+        ?s a <http://data.vlaanderen.be/ns/besluit#Zitting> .
+        ?s ?p ?o.
+        FILTER NOT EXISTS {
+          ?s <http://mu.semte.ch/vocabularies/ext/behandelt> ?o.
+          ?o a <http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt> .
+        }
+      }
+    }
+
+## remove documents
+
+      DELETE {
+        GRAPH <http://mu.semte.ch/graphs/oslo-decisions/landing> {
+          ?s ?p ?o.
+        }
+      }WHERE {
+        GRAPH <http://mu.semte.ch/graphs/oslo-decisions/landing> {
+          ?s a <http://xmlns.com/foaf/0.1/Document>.
+          ?s ?p ?o.
+          FILTER NOT EXISTS {
+          VALUES ?thing {
+    <http://data.vlaanderen.be/ns/besluit#BehandelingVanAgendapunt>
+    <http://data.vlaanderen.be/ns/besluit#Stemming>
+    <http://data.vlaanderen.be/ns/besluit#Besluit>
+    <http://data.vlaanderen.be/ns/besluit#Zitting>
+
+            }
+            ?oo ?pp ?s .
+            ?oo a ?thing.
+          }
+        }
+      }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# DECIDe 
+# DECIDe
 
 This repository contains all configuration to get the DECIDe microservices stack running. It is very much a work in progress. Documentation for each use case is provided below.
 
 ## What's included?
 
 This repository contains multiple docker-compose files
-- *docker-compose.yml* provides the backend components.
-- *docker-compose.dev.yml* provides small changes for development purposes.
+
+- _docker-compose.yml_ provides the backend components.
+- _docker-compose.dev.yml_ provides small changes for development purposes.
   - Publishes the entrypoint to the services on port 80, so all endpoints can be reached easily.
   - Publishes the triplestore on port 8890, so the SPARQL endpoint (`/sparql`) can be reached easily.
 
@@ -74,6 +75,8 @@ services:
 ```
 
 Note: the AI services (used in the other use cases) will be configurable so they can directly work with OSLO-compliant data
+
+The OSLO configuration depends on consuming all data from a full LBLOD harvester. This results in a lot of extra data that is not necessary, see ./OSLO_PRUNING.md for info on how to reduce the database size after initial load.
 
 #### OParl (Freiburg)
 

--- a/config/migrations/20260316075947-org-and-eenheid-to-org.sparql
+++ b/config/migrations/20260316075947-org-and-eenheid-to-org.sparql
@@ -1,0 +1,13 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+INSERT {
+  GRAPH ?g {
+    ?org a org:Organization.
+  }
+}WHERE {
+  GRAPH ?g {
+    VALUES ?type { besluit:Bestuurseenheid besluit:Bestuursorgaan }.
+    ?org a ?type .
+  }
+}


### PR DESCRIPTION
This adds a description of how to prune oslo data after initial load. This pruning allows us to have a smaller starting database that we can easily copy to different environments instead of the full 24gb beast it was.

I also noticed that OSLO bestuurseenheden and bestuursorganen were not org:Organizations yet. I added a migration that fixes this.