### PR TITLE
keep ds for the dataspace (dcat) part of the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ We use dispatcher v2, which dispatches different frontends based on hostname. If
 
 ```
 127.0.0.1 dashboard.localhost
-127.0.0.1 dcat.localhost
+127.0.0.1 ds.localhost
 127.0.0.1 human-validator.localhost
 127.0.0.1 yasgui.localhost
 ```

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -347,15 +347,15 @@ defmodule Dispatcher do
   end
 
   # dcat
-  match "/index.html",  %{reverse_host: ["dcat" | _rest], layer: :static} do
+  match "/index.html",  %{reverse_host: ["ds" | _rest], layer: :static} do
     forward(conn, [], "http://frontend-dcat/index.html")
   end
 
-  get "/assets/*path", %{reverse_host: ["dcat" | _rest], layer: :static} do
+  get "/assets/*path", %{reverse_host: ["ds" | _rest], layer: :static} do
     forward(conn, path, "http://frontend-dcat/assets/")
   end
 
-  get "/@appuniversum/*path",  %{reverse_host: ["dcat" | _rest], layer: :static} do
+  get "/@appuniversum/*path",  %{reverse_host: ["ds" | _rest], layer: :static} do
     forward(conn, path, "http://frontend-dcat/@appuniversum/")
   end
 
@@ -396,7 +396,7 @@ defmodule Dispatcher do
     forward(conn, [], "http://frontend-harvesting/index.html")
   end
 
-  match "/*_path", %{reverse_host: ["dcat" | _rest], accept: %{html: true}, layer: :frontend} do
+  match "/*_path", %{reverse_host: ["ds" | _rest], accept: %{html: true}, layer: :frontend} do
     forward(conn, [], "http://frontend-dcat/index.html")
   end
 


### PR DESCRIPTION
we already communicated ds as a subdomain for dcat, let's keep it