### PR TITLE
allow voting on annotations

### DIFF
--- a/config/authorization/decide.lisp
+++ b/config/authorization/decide.lisp
@@ -147,6 +147,11 @@
 (define-graph human-validation ("http://mu.semte.ch/graphs/public/human-validation/")
   ("ext:ReviewAnnotation" -> _))
 
+(define-graph ai ("http://mu.semte.ch/graphs/ai")
+  ("oa:Annotation" -> _)
+  ("oa:SpecificResource" -> _)
+  ("oa:TextPositionSelector" -> _))
+
 (supply-allowed-group "public")
 
 (grant (read)
@@ -167,6 +172,10 @@
 
 (grant (read)
        :to-graph harvested-pdf
+       :for-allowed-group "public")
+
+(grant (read)
+       :to-graph ai
        :for-allowed-group "public")
 
 (grant (read write)

--- a/config/authorization/decide.lisp
+++ b/config/authorization/decide.lisp
@@ -144,6 +144,9 @@
   ("foaf:OnlineAccount" -> _)
   ("adms:Identifier" -> _))
 
+(define-graph human-validation ("http://mu.semte.ch/graphs/public/human-validation/")
+  ("ext:ReviewAnnotation" -> _))
+
 (supply-allowed-group "public")
 
 (grant (read)
@@ -169,6 +172,41 @@
 (grant (read write)
        :to harvesting
        :for "logged-in")
+
+;; our ODRL implementation currently cannot handle scopes, but it would be more secure to do so
+; (with-scope "http://services.semantic.works/annotation-review-service"
+;   (grant (read write)
+;     :to human-validation
+;     :for "public"
+;   ))       
+
+; (with-scope "http://services.semantic.works/annotation-review-service"
+;   (grant (read)
+;     :to public
+;     :for "public"
+;   ))       
+
+; (with-scope "http://services.semantic.works/annotation-review-service"
+;   (grant (read)
+;     :to harvested-gent
+;     :for "public"
+;   ))       
+
+; (with-scope "http://services.semantic.works/annotation-review-service"
+;   (grant (read)
+;     :to harvested-freiburg
+;     :for "public"
+;   ))       
+
+; (with-scope "http://services.semantic.works/annotation-review-service"
+;   (grant (read)
+;     :to harvested-pdf
+;     :for "public"
+;   ))       
+;; instead we need to give public write access to user reviews
+(grant (read write)
+       :to-graph human-validation
+       :for-allowed-group "public")
 
 (supply-allowed-group "logged-in"
                       :query "PREFIX session: <http://mu.semte.ch/vocabularies/session/>

--- a/config/authorization/decide.lisp
+++ b/config/authorization/decide.lisp
@@ -144,7 +144,7 @@
   ("foaf:OnlineAccount" -> _)
   ("adms:Identifier" -> _))
 
-(define-graph human-validation ("http://mu.semte.ch/graphs/public/human-validation/")
+(define-graph human-validation ("http://mu.semte.ch/graphs/public/human-validation")
   ("ext:ReviewAnnotation" -> _))
 
 (define-graph ai ("http://mu.semte.ch/graphs/ai")

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -272,6 +272,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://resource/specific-resources/"
   end
 
+  match "/text-position-selectors/*path", %{ accept: [:json], layer: :resources } do
+    Proxy.forward conn, path, "http://resource/text-position-selectors/"
+  end
+
   match "/locations/*path", %{ accept: [:json], layer: :resources } do
     Proxy.forward conn, path, "http://resource/locations/"
   end

--- a/config/resources/annotation.lisp
+++ b/config/resources/annotation.lisp
@@ -30,4 +30,5 @@
   :properties `((:start :number ,(s-prefix "oa:start"))
                 (:end :number ,(s-prefix "oa:end")))
   :features '(include-uri)
-  :resource-base (s-url "http://data.lblod.info/id/text-position-selector/"))
+  :resource-base (s-url "http://data.lblod.info/id/text-position-selector/")
+  :on-path "text-position-selectors")


### PR DESCRIPTION
mu-auth config to allow registering reviewannotations (which have both oa:Annotation and ext:ReviewAnnotation as a type) 