### PR TITLE
remove langless preflabels for concepts that have a pref label with a language

### DIFF
--- a/config/migrations/20260331123021-remove-langless-preflabels-if-lang-exists.sparql
+++ b/config/migrations/20260331123021-remove-langless-preflabels-if-lang-exists.sparql
@@ -1,0 +1,14 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>  
+DELETE {
+  GRAPH ?g {
+    ?s skos:prefLabel ?label1.
+  }
+}
+
+WHERE {
+  GRAPH ?g {
+    ?s skos:prefLabel ?label1.
+  }
+  ?s skos:prefLabel ?label2.
+  FILTER (?label1 != ?label2 && STRLEN(LANG(?label1)) = 0)
+} 


### PR DESCRIPTION
some concepts, like flemish bestuurseenheden have a preflabel with and one without a language. This results in resources returning the concept twice. let's remove the labels without a language if the one with a language exists.