### PR TITLE
Change datatype ext:propertyPathForText to string

### DIFF
--- a/config/resources/job.json
+++ b/config/resources/job.json
@@ -70,7 +70,7 @@
                     "predicate": "ext:graphForTargets"
                 },
                 "property-path-for-text": {
-                    "type": "url",
+                    "type": "string",
                     "predicate": "ext:propertyPathForText"
                 },
                 "confidence-threshold": {
@@ -106,7 +106,7 @@
                     "predicate": "ext:graphForTargets"
                 },
                 "property-path-for-text": {
-                    "type": "url",
+                    "type": "string",
                     "predicate": "ext:propertyPathForText"
                 },
                 "confidence-threshold": {


### PR DESCRIPTION
the property path can be a chain of predicates, eg:
```
<http://data.europa.eu/eli/ontology#is_realized_by> / <https://data.europarl.europa.eu/def/epvoc#expressionContent>
```

Before it was only possible to add 1 predicate (and thus datatype was URL)

Related PR: https://github.com/lblod/frontend-harvesting-self-service/pull/54