### PR TITLE
Add shacl for organizations

### DIFF
--- a/compose/reporting.yml
+++ b/compose/reporting.yml
@@ -1,6 +1,6 @@
 services:
   report-generation:
-    image: lblod/loket-report-generation-service:0.8.6-beta-6
+    image: lblod/loket-report-generation-service:0.8.6-beta-7
     environment:
       DEFAULT_GRAPH: "http://mu.semte.ch/graphs/reports"
       ONLY_KEEP_LATEST_REPORT: true

--- a/compose/reporting.yml
+++ b/compose/reporting.yml
@@ -1,6 +1,6 @@
 services:
   report-generation:
-    image: lblod/loket-report-generation-service:0.8.6-beta-5
+    image: lblod/loket-report-generation-service:0.8.6-beta-6
     environment:
       DEFAULT_GRAPH: "http://mu.semte.ch/graphs/reports"
       ONLY_KEEP_LATEST_REPORT: true

--- a/config/reports/shacl-report.js
+++ b/config/reports/shacl-report.js
@@ -40,7 +40,8 @@ const namedGraphs = [
     'http://mu.semte.ch/graphs/public/freiburg',
     'http://mu.semte.ch/graphs/public/gent',
     'http://mu.semte.ch/graphs/public/pdf',
-]
+];
+
 const safeNamedGraphs = namedGraphs
   .map((uri) => sparqlEscapeUri(uri))
   .join('\n');
@@ -116,10 +117,31 @@ async function fillDataDataset(targetClass, offset, dataDataset) {
 
     // Shorten strings to avoid insert problems
     dataDataset.forEach((quad) => {
-        if (quad.object.termType === 'Literal' && typeof quad.object.value === 'string') {
-            const shorterObject = literal(quad.object.value.substr(0, MAX_STRING_LENGTH), quad.object.datatype)
-            dataDataset.addQuad(quad.subject, quad.predicate, shorterObject);
+        if (quad.object.termType === 'Literal' && 
+            typeof quad.object.value === 'string' &&
+            quad.object.value.length > MAX_STRING_LENGTH
+        ) {
+            const shortenedValue = quad.object.value.slice(0, MAX_STRING_LENGTH);
+            let shorterObject;
+            if (quad.object.language) {
+                // language-tagged literal
+                shorterObject = literal(shortenedValue, quad.object.language);
+            } else if (quad.object.datatype) {
+                // typed literal
+                shorterObject = literal(shortenedValue, quad.object.datatype);
+            } else {
+                // plain literal fallback
+                shorterObject = literal(shortenedValue);
+            }
+
+            // Replace quad
             dataDataset.removeQuad(quad);
+            dataDataset.addQuad(
+                quad.subject,
+                quad.predicate,
+                shorterObject,
+                quad.graph // preserve graph if present
+            );
         }
     })
 }

--- a/config/reports/shacl/organization.ttl
+++ b/config/reports/shacl/organization.ttl
@@ -1,0 +1,90 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix eli: <http://data.europa.eu/eli/ontology#> .
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix epvoc: <https://data.europarl.europa.eu/def/epvoc#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+<http://example.org/organization_1_shape>
+    a sh:NodeShape ;
+    sh:targetClass <http://www.w3.org/ns/org#Organization> ;
+    sh:prefixes [ sh:declare [
+        a sh:PrefixDeclaration ;
+        sh:namespace "http://mu.semte.ch/vocabularies/core/"^^xsd:anyURI ;
+        sh:prefix "mu" ;
+    ] ], [ sh:declare [
+        a sh:PrefixDeclaration ;
+        sh:namespace "http://data.europa.eu/eli/ontology#"^^xsd:anyURI ;
+        sh:prefix "eli" ;
+    ] ], [ sh:declare [
+        a sh:PrefixDeclaration ;
+        sh:namespace "http://purl.org/dc/terms/"^^xsd:anyURI ;
+        sh:prefix "dct" ;
+    ] ], [ sh:declare [
+        a sh:PrefixDeclaration ;
+        sh:namespace "http://www.w3.org/ns/org#"^^xsd:anyURI ;
+        sh:prefix "org" ;
+    ] ], [ sh:declare [
+        a sh:PrefixDeclaration ;
+        sh:namespace "http://data.vlaanderen.be/ns/besluit#"^^xsd:anyURI ;
+        sh:prefix "besluit" ;
+    ] ], [ sh:declare [
+        a sh:PrefixDeclaration ;
+        sh:namespace "https://data.europarl.europa.eu/def/epvoc#"^^xsd:anyURI ;
+        sh:prefix "epvoc" ;
+    ] ], [ sh:declare [
+        a sh:PrefixDeclaration ;
+        sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
+        sh:prefix "skos" ;
+    ] ], [ sh:declare [
+        a sh:PrefixDeclaration ;
+        sh:namespace "http://www.w3.org/ns/dcat#"^^xsd:anyURI ;
+        sh:prefix "dcat" ;
+    ] ];
+
+    sh:property [
+        sh:path mu:uuid ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:name "identifier" ;
+        sh:description "De identifier van de organisatie." ;
+        sh:path dct:identifier ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:name "preferred label" ;
+        sh:description "De preferred label van de organisatie." ;
+        sh:path skos:prefLabel ;
+        sh:nodeKind rdf:langString ;
+        sh:minCount 0 ;
+    ] ;
+    sh:property [
+        sh:name "classificatie" ;
+        sh:description "De classificatie van de organisatie." ;
+        sh:path org:classification ;
+        sh:nodeKind sh:IRI ;
+        sh:minCount 0 ;
+    ] ;
+    sh:property [
+        sh:name "heeft suborganisatie" ;
+        sh:description "Geeft de hiërarchische structuur van organisaties of organisatie-eenheden weer; duidt een organisatie aan die een onderdeel of dochterorganisatie van deze organisatie is." ;
+        sh:path org:hasSuborganization ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+    sh:property [
+        sh:name "contactinfo" ;
+        sh:description "Informatie zoals email, telefoon... die toelaat de Organisatie te contacteren." ;
+        sh:path dcat:contactPoint ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:IRI ;
+    ] .

--- a/config/reports/shacl/organization.ttl
+++ b/config/reports/shacl/organization.ttl
@@ -64,7 +64,7 @@
         sh:name "preferred label" ;
         sh:description "De preferred label van de organisatie." ;
         sh:path skos:prefLabel ;
-        sh:nodeKind rdf:langString ;
+        sh:datatype rdf:langString ;
         sh:minCount 0 ;
     ] ;
     sh:property [


### PR DESCRIPTION
## 🗒️ Description

This PR adds a new shape to validate the structure of organizations.

## 🦮 How to test

The best way to test the new SHACL shape is by setting up a temporary graph:

1. Insert organization that is good, and one that is bad:
```
prefix sh: <http://www.w3.org/ns/shacl#> 
prefix xsd: <http://www.w3.org/2001/XMLSchema#> 
prefix dct: <http://purl.org/dc/terms/> 
prefix eli: <http://data.europa.eu/eli/ontology#> 
prefix mu: <http://mu.semte.ch/vocabularies/core/> 
prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
prefix epvoc: <https://data.europarl.europa.eu/def/epvoc#> 
prefix org: <http://www.w3.org/ns/org#> 
prefix skos: <http://www.w3.org/2004/02/skos/core#> 
prefix dcat: <http://www.w3.org/ns/dcat#> 

INSERT DATA {
GRAPH <http://mu.semte.ch/graphs/temp/org> {
<http://example.org/good-org> a org:Organization ;
 mu:uuid "123" ;
 dct:identifier "123";
 skos:prefLabel "My good org"@en .

<http://example.org/bad-org> a org:Organization ;
 dct:identifier "123";
 skos:prefLabel "My bad org has no uuid" .
}
}
```
2. Adapt the named graphs in `config/reports/shacl-report.js`:
```
const namedGraphs = [
    'http://mu.semte.ch/graphs/temp/org'
];
```
3. Restart the `report-generation` service: `drc restart report-generation`
4. Check the latest report `http://localhost/shacl-reports/shacl-reports/latest/issues`. This should result in two errors:
<img width="1004" height="911" alt="image" src="https://github.com/user-attachments/assets/f613de74-b8b2-4a8e-8538-7827334080bc" />

