### PR TITLE
refactor: use scopes to limit access to annotation review data

### DIFF
--- a/compose/validation.yml
+++ b/compose/validation.yml
@@ -11,6 +11,7 @@ services:
       - logging=true
     logging: *default-logging
     environment:
+      DEFAULT_MU_AUTH_SCOPE: "http://services.semantic.works/annotation-review-service"
       TZ: Europe/Brussels
   frontend-human-validator:
     image: lblod/frontend-decide-human-validator:0.0.4

--- a/config/authorization/config.lisp
+++ b/config/authorization/config.lisp
@@ -24,3 +24,7 @@
 
 ;; ACCESS RIGHTS
 ;; The access policy is defined using ODRL in `./config.ttl'.
+;; If you do want to use the Lisp configuration, uncomment the following 3 lines:
+;; (setf *use-odrl-config-p* nil) ; Disables loading the ODRL config
+;; (unless *use-odrl-config-p* ; Extra check to be sure only correct file is loaded
+;;   (load "./config/decide.lisp")) ; Load the policy in the lisp file

--- a/config/authorization/config.ttl
+++ b/config/authorization/config.ttl
@@ -51,7 +51,12 @@ ext:decideAuthorizationPolicy a odrl:Set ;
     ext:allowReadForOsloOrganizations ,
     ext:allowReadForAiSlice ,
     ext:allowReadForHumanValidation ,
-    ext:allowWriteForHumanValidation .
+    ext:allowWriteForHumanValidation ,
+    ext:allowReadAnnotationForPublic ,
+    ext:allowReadAnnotationForGhent ,
+    ext:allowReadAnnotationForFreiburg ,
+    ext:allowReadAnnotationForPdf ,
+    ext:allowAnnotationReadForAiSlice .
 
 # Parties for groups
 ext:decideSystem a odrl:Party ;
@@ -193,14 +198,46 @@ ext:allowReadForHumanValidation a odrl:Permission ;
   odrl:action odrl:read ;
   odrl:target ext:decideHumanValidationSlice ;
   odrl:assigner ext:decideSystem ;
-  odrl:assignee ext:publicParty .
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
 
-# TODO: once scopes are supported write should only be granted to `annotation-review-service`, see `decide.lisp`
 ext:allowWriteForHumanValidation a odrl:Permission ;
   odrl:action odrl:modify ;
   odrl:target ext:decideHumanValidationSlice ;
   odrl:assigner ext:decideSystem ;
-  odrl:assignee ext:publicParty .
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadAnnotationForPublic a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decidePublicSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadAnnotationForGhent a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedGentSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadAnnotationForFreiburg a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedFreiburgSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadAnnotationForPdf a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedPdfSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowAnnotationReadForAiSlice a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideAiSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
 
 # Assets (SHACL shapes) for type specifications
 ext:BesluitAdministrativeUnitAsset a odrl:Asset, sh:NodeShape ;

--- a/config/authorization/decide.lisp
+++ b/config/authorization/decide.lisp
@@ -185,40 +185,35 @@
        :to harvesting
        :for "logged-in")
 
-;; our ODRL implementation currently cannot handle scopes, but it would be more secure to do so
-; (with-scope "http://services.semantic.works/annotation-review-service"
-;   (grant (read write)
-;     :to human-validation
-;     :for "public"
-;   ))       
+(with-scope "http://services.semantic.works/annotation-review-service"
+  (grant (read write)
+    :to-graph human-validation
+    :for-allowed-group "public"))
 
-; (with-scope "http://services.semantic.works/annotation-review-service"
-;   (grant (read)
-;     :to public
-;     :for "public"
-;   ))       
+(with-scope "http://services.semantic.works/annotation-review-service"
+  (grant (read)
+    :to-graph public
+    :for-allowed-group "public"))
 
-; (with-scope "http://services.semantic.works/annotation-review-service"
-;   (grant (read)
-;     :to harvested-gent
-;     :for "public"
-;   ))       
+(with-scope "http://services.semantic.works/annotation-review-service"
+  (grant (read)
+    :to-graph harvested-gent
+    :for-allowed-group "public"))
 
-; (with-scope "http://services.semantic.works/annotation-review-service"
-;   (grant (read)
-;     :to harvested-freiburg
-;     :for "public"
-;   ))       
+(with-scope "http://services.semantic.works/annotation-review-service"
+  (grant (read)
+    :to-graph harvested-freiburg
+    :for-allowed-group "public"))
 
-; (with-scope "http://services.semantic.works/annotation-review-service"
-;   (grant (read)
-;     :to harvested-pdf
-;     :for "public"
-;   ))       
-;; instead we need to give public write access to user reviews
-(grant (read write)
-       :to-graph human-validation
-       :for-allowed-group "public")
+(with-scope "http://services.semantic.works/annotation-review-service"
+  (grant (read)
+    :to-graph harvested-pdf
+    :for-allowed-group "public"))
+
+(with-scope "http://services.semantic.works/annotation-review-service"
+  (grant (read)
+    :to-graph ai
+    :for-allowed-group "public"))
 
 (supply-allowed-group "logged-in"
                       :query "PREFIX session: <http://mu.semte.ch/vocabularies/session/>


### PR DESCRIPTION
Initially sparql-parser's ODRL configuration lacked support for scopes. Consequently, in #74 we had to provide public read and write access to the `human-validation` graph[^1].

We have introduced support for scopes in sparql-parser's ODRL feature build. This allows us to update the ODRL (and Lisp) configuration with scopes as to limit write access to the `human-validation` graph to only the `annotation-review-service`.

## How to test
0. Check out the branch for this PR.
1. Make sure to pull the latest feature-build for sparql-parser, only this one supports scopes: `docker compose pull database`
2. Pull the latest version of the annotation-review-service: `docker compose pull annotation-review`
3. (Re-)up the `database` and `annotation-review` services: `docker compose up -d database annotation-review`.
4. You will need the latest version of the `frontend-decide-human-validator` for the  following steps. So either
   a. Add the following entry to your `docker-compose.override.yml`. Afterwards, pull and re-up this frontend service.
   ```yml
    frontend-human-validator:
      image: lblod/frontend-decide-human-validator:latest
   ```
   b. Run a local development version of that frontend.
5. Browse to http://human-validator.localhost/expressions
6. Choose one of the shown decisions and click on its title (it does not matter which one)
7. Validate some entries by clicking on the thumbs up and down icons. Make sure the appropriate icon gets highlighted and the numbers change.
8. Browse to http://human-validator.localhost/validate-expression-labels
9. Validate some entries by clicking on the thumbs up and down icons. Make sure the appropriate icon gets highlighted and the numbers change.
10. Repeat steps 5-9 in another session (e.g. using a private browsing window) and check whether the numbers shown in for both sessions match.

If you opted for option 4.b for the frontend, browse to http://localhost:4200/expressions and http://localhost:4200/validate-expression-labels in steps 5 and 8 respectively.

## Notes
Support for scopes was added directly to sparql-parser's ODRL feature branch, see [#12](https://github.com/mu-semtech/sparql-parser/pull/12). The relevant diff for that branch can be found [here](https://github.com/mu-semtech/sparql-parser/compare/cc0395f..8512ccd).

## Related tickets
- LBRON-1320

[^1]: Using sudo queries would have been another option. But with the introduction of scopes in sparql-parser this option is somewhat deprecated.