### PR TITLE
feat: add annotation-job-splitter service

### DIFF
--- a/compose/pipeline.yml
+++ b/compose/pipeline.yml
@@ -36,7 +36,7 @@ services:
     labels:
       - 'logging=true'
   job-controller:
-    image: lblod/job-controller-service:1.2.0
+    image: lblod/job-controller-service:1.3.0-beta-parallel-tasks
     volumes:
       - ../config/job-controller:/config
     environment:

--- a/compose/pipeline.yml
+++ b/compose/pipeline.yml
@@ -56,3 +56,10 @@ services:
       - 'logging=true'
     restart: always
     logging: *default-logging
+  annotation-job-splitter:
+    # TODO: Change to tagged version once available
+    image: lblod/annotation-job-splitter-service:feature-initial-implementation-tasks
+    restart: always
+    logging: *default-logging
+    labels:
+      - 'logging=true'

--- a/compose/pipeline.yml
+++ b/compose/pipeline.yml
@@ -57,8 +57,7 @@ services:
     restart: always
     logging: *default-logging
   annotation-job-splitter:
-    # TODO: Change to tagged version once available
-    image: lblod/annotation-job-splitter-service:feature-initial-implementation-tasks
+    image: lblod/annotation-job-splitter-service:0.0.1
     restart: always
     logging: *default-logging
     labels:

--- a/config/delta/annotation-job-splitter.js
+++ b/config/delta/annotation-job-splitter.js
@@ -1,0 +1,24 @@
+export default [
+  {
+    match: {
+      predicate: {
+        type: "uri",
+        value: "http://www.w3.org/ns/adms#status",
+      },
+      object: {
+        type: "uri",
+        value: "http://redpencil.data.gift/id/concept/JobStatus/scheduled",
+      },
+    },
+    callback: {
+      method: "POST",
+      url: "http://annotation-job-splitter/delta",
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+      sendMatchesOnly: true,
+    },
+  },
+];

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -4,6 +4,7 @@ import pdfToEli from './pdf-to-eli';
 import osloToEli from './oslo-to-eli';
 import search from './search';
 import resource from './resource';
+import annotationJobSplitter from './annotation-job-splitter';
 
 export default [
   ...resource,
@@ -12,4 +13,5 @@ export default [
   ...pdfToEli,
   ...osloToEli,
   ...search,
+  ...annotationJobSplitter,
 ];

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -47,7 +47,7 @@
       }
     ]
   },
-  "http://lblod.data.gift/id/jobs/concept/JobOperation/eli-enrichment": {
+  "http://lblod.data.gift/id/jobs/concept/JobOperation/ner-and-nel-annotations": {
     "tasksConfiguration": [
       {
         "currentOperation": null,

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -55,19 +55,25 @@
         "nextIndex": "0"
       },
       {
-        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/eli-translation",
+        "currentOperation":"http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextOperation":         "http://lblod.data.gift/id/jobs/concept/TaskOperation/annotation-split-tasks",
         "nextIndex": "1"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/annotation-split-tasks",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/eli-translation",
+        "nextIndex": "2",
+        "external": true
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/eli-translation",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/eli-entity-extracting",
-        "nextIndex": "2"
+        "nextIndex": "3"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/eli-entity-extracting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/eli-entity-linking",
-        "nextIndex": "3"
+        "nextIndex": "4"
       }
     ]
   },
@@ -118,13 +124,19 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/annotate",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/training-split-tasks",
         "nextIndex": "1"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/training-split-tasks",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/annotate",
+        "nextIndex": "2",
+        "external": true
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/annotate",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/train",
-        "nextIndex": "2"
+        "nextIndex": "3"
       }
     ]
   },
@@ -137,13 +149,19 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/annotate",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/evaluation-split-tasks",
         "nextIndex": "1"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/evaluation-split-tasks",
+        "nextIndex": "2",
+        "external": true
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/annotate",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/assess-impact",
-        "nextIndex": "2"
+        "nextIndex": "3"
       }
     ]
   }


### PR DESCRIPTION
Adds the new [annotation-job-splitter](https://github.com/lblod/annotation-job-splitter-service) service to this application.

This service will be responsible to split annotation jobs into appropriate subtasks that can be executed by services in the (AI) pipelines. To this end, the configuration for the `deltanotifier` has been updated to forward the necessary delta messages to the splitter service.

## Notes
The updated job-controller configuration relies on the features added in [#9](https://github.com/lblod/job-controller-service/pull/9)

## How to test
See the PR on the service's initial implementation: [#1](https://github.com/lblod/annotation-job-splitter-service/pull/1)

## TODO
- [x] Use a tagged version of the new service instead of a feature build

## Related tickets
- LBRON-1311
- LBRON-1373