### PR TITLE
fix(job-controller): correct operations in task configuration

### DIFF
--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -153,8 +153,8 @@
         "nextIndex": "1"
       },
       {
-        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/evaluation-split-tasks",
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/evaluation-split-tasks",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/codelist-matching/annotate",
         "nextIndex": "2",
         "external": true
       },


### PR DESCRIPTION
The job configuration for `codelist-matching/evaluation` contained an incorrect
entry where the current and next operation where the same as the previous entry.
This corrects those operations to the correct ones.

Because the faulty entry is an `external` one, this had no visible effect on the
overall behaviour.  The splitter service worked as expected, creating the
required tasks.  Once these tasks are marked successful the controller just
picked them up with the last entry in the configuration.

This error was introduced in #88