### PR TITLE
feat: store ODRL authorization policy and allow public read

### DIFF
--- a/config/authorization/config.ttl
+++ b/config/authorization/config.ttl
@@ -33,7 +33,6 @@
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix wikidata: <http://www.wikidata.org/entity/> .
 @prefix wot: <https://www.w3.org/2019/wot/security#> .
-@prefix sh: <http://www.w3.org/ns/shacl#> .
 
 ext:muAuthProfile a odrl:Profile ;
   dct:description "ODRL profile describing access to mu-auth resources." .

--- a/config/authorization/config.ttl
+++ b/config/authorization/config.ttl
@@ -56,7 +56,8 @@ ext:decideAuthorizationPolicy a odrl:Set ;
     ext:allowReadAnnotationForGhent ,
     ext:allowReadAnnotationForFreiburg ,
     ext:allowReadAnnotationForPdf ,
-    ext:allowAnnotationReadForAiSlice .
+    ext:allowAnnotationReadForAiSlice ,
+    ext:allowPublicReadForAuthz .
 
 # Parties for groups
 ext:decideSystem a odrl:Party ;
@@ -457,7 +458,8 @@ ext:ExtReviewAnnotationAsset a odrl:Asset, sh:NodeShape ;
   sh:targetClass ext:ReviewAnnotation .
 
 ext:NodeShapeAsset a odrl:Asset, sh:NodeShape ;
-  odrl:partOf ext:decideHarvestingSlice ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decideAuthzSlice ;
   sh:targetClass sh:NodeShape .
 
 ext:CogsScheduledJobAsset a odrl:Asset, sh:NodeShape ;
@@ -530,3 +532,39 @@ ext:WotBasicSecuritySchemeAsset a odrl:Asset, sh:NodeShape ;
 ext:WotOAuth2SecuritySchemeAsset a odrl:Asset, sh:NodeShape ;
   odrl:partOf ext:decideHarvestingSlice ;
   sh:targetClass wot:OAuth2SecurityScheme .
+
+
+# Access rights to the stored copy of this policy itself
+ext:decideAuthzSlice a odrl:AssetCollection ;
+  vcard:fn "odrl-authorization-policy" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/odrl-authorization-policy> .
+
+ext:OdrlProfileAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:Profile .
+
+ext:OdrlPartyAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:Party .
+
+ext:OdrlPartyCollectionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:PartyCollection .
+
+ext:OdrlAssetCollectionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:AssetCollection .
+
+ext:OdrlAssetAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:Asset .
+
+ext:OdrlPermissionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:Permission .
+
+ext:allowPublicReadForAuthz a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideAuthzSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .

--- a/config/migrations/insert-odrl-authorization-policy/20260504133512-insert-odrl-authorization-policy.graph
+++ b/config/migrations/insert-odrl-authorization-policy/20260504133512-insert-odrl-authorization-policy.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/odrl-authorization-policy

--- a/config/migrations/insert-odrl-authorization-policy/20260504133512-insert-odrl-authorization-policy.ttl
+++ b/config/migrations/insert-odrl-authorization-policy/20260504133512-insert-odrl-authorization-policy.ttl
@@ -1,0 +1,565 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix besluit: <http://data.vlaanderen.be/ns/besluit#> .
+@prefix cms: <http://mu.semte.ch/vocabulary/cms/> .
+@prefix cogs: <http://vocab.deri.ie/cogs#> .
+@prefix core: <http://open-services.net/ns/core#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix defend: <https://d3fend.mitre.org/ontologies/d3fend#> .
+@prefix eli: <http://data.europa.eu/eli/ontology#> .
+@prefix eli-dl: <http://data.europa.eu/eli/eli-draft-legislation-ontology#> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+@prefix harvesting: <http://lblod.data.gift/vocabularies/harvesting/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#> .
+@prefix ndo: <http://oscaf.sourceforge.net/ndo.html#> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix oparl-temp: <http://mu.semte.ch/vocabularies/ext/oparl/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix perceel: <https://data.vlaanderen.be/ns/perceel#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix schema: <http://schema.org/> .
+@prefix security: <http://lblod.data.gift/vocabularies/security/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tasks: <http://redpencil.data.gift/vocabularies/tasks/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix wikidata: <http://www.wikidata.org/entity/> .
+@prefix wot: <https://www.w3.org/2019/wot/security#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ext:muAuthProfile a odrl:Profile ;
+  dct:description "ODRL profile describing access to mu-auth resources." .
+
+ext:decideAuthorizationPolicy a odrl:Set ;
+  odrl:profile ext:muAuthProfile ;
+  odrl:permission ext:allowReadForPublic ,
+    ext:allowReadForOrganizations ,
+    ext:allowReadForHarvestedFreiburg ,
+    ext:allowReadForHarvestedGent ,
+    ext:allowReadForHarvestedPdf ,
+    ext:allowReadForHarvesting ,
+    ext:allowWriteForHarvesting ,
+    ext:allowReadForOrganization ,
+    ext:allowReadForOsloOrganizations ,
+    ext:allowReadForAiSlice ,
+    ext:allowReadForHumanValidation ,
+    ext:allowWriteForHumanValidation ,
+    ext:allowReadAnnotationForPublic ,
+    ext:allowReadAnnotationForGhent ,
+    ext:allowReadAnnotationForFreiburg ,
+    ext:allowReadAnnotationForPdf ,
+    ext:allowAnnotationReadForAiSlice ,
+    ext:allowPublicReadForAuthz .
+
+# Parties for groups
+ext:decideSystem a odrl:Party ;
+  vcard:fn "DECIDe System" ;
+  dct:description "The DECIDe system party used as an assigner of the permissions in this policy." .
+
+ext:publicParty a odrl:PartyCollection ;
+  vcard:fn "public" ;
+  dct:description "This party represent all (possibly not logged in) users of the system." .
+
+ext:authenticatedParty a odrl:PartyCollection ;
+  vcard:fn "logged-in" ;
+  ext:definedBy """PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+  SELECT DISTINCT ?account
+  WHERE {
+    <SESSION_ID> session:account ?account .
+  }""" ;
+  dct:description "This represents all logged in users of the system." .
+
+ext:organizationMemberParty a odrl:PartyCollection ;
+  vcard:fn "organization-member" ;
+  ext:queryParameters "session_group" ;
+  ext:definedBy """PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+          PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+          SELECT ?session_group ?session_role WHERE {
+            <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group.
+          }""" .
+
+# Asset collections for graphs
+ext:decideHarvestingSlice a odrl:AssetCollection ;
+  vcard:fn "harvesting" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/harvesting> ;
+  dct:description "This asset collection contains all information that is available in as part the harvesting done by the DECIDE app." .
+
+# NOTE (24/03/2026): plural organizationS
+ext:decideOrganizationsSlice a odrl:AssetCollection ;
+  vcard:fn "organizations" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/organizations> .
+
+# NOTE (24/03/2026): singular organization
+ext:decideOrganizationSlice a odrl:AssetCollection ;
+  vcard:fn "organization" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/organizations/> .
+
+# NOTE (10/02/2026): Graph <http://mu.semte.ch/graphs/organizations> does NOT
+# contain the `besluit:Bestuurseenheid` type (only `org:Organization`), using
+# that graph causes resource service to bug out for acm/idm login.
+ext:decideOsloOrganizationsSlice a odrl:AssetCollection ;
+  vcard:fn "oslo-organizations" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/bestuurseenheden-bestuursorganen> .
+
+ext:decideHarvestedFreiburgSlice a odrl:AssetCollection ;
+  vcard:fn "harvested-freiburg" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/public/freiburg> .
+
+ext:decideHarvestedGentSlice a odrl:AssetCollection ;
+  vcard:fn "harvested-gent" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/public/gent> .
+
+ext:decideHarvestedPdfSlice a odrl:AssetCollection ;
+  vcard:fn "harvested-pdf" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/public/pdf> .
+
+ext:decidePublicSlice a odrl:AssetCollection ;
+  vcard:fn "public" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/public> ;
+  dct:description "This asset collection contains all information that is available to the public in the context of the DECIDe app." .
+
+ext:decideHumanValidationSlice a odrl:AssetCollection ;
+  vcard:fn "human-validation" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/public/human-validation> .
+
+ext:decideAiSlice a odrl:AssetCollection ;
+  vcard:fn "ai" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/ai> .
+
+# Permissions for grants
+ext:allowReadForPublic a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decidePublicSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForOrganizations a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideOrganizationsSlice ; # NOTE (24/03/2026): plural organizationS
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForHarvestedFreiburg a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedFreiburgSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForHarvestedGent a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedGentSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForHarvestedPdf a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedPdfSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForHarvesting a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestingSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:authenticatedParty .
+
+ext:allowWriteForHarvesting a odrl:Permission ;
+  odrl:action odrl:modify ;
+  odrl:target ext:decideHarvestingSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:authenticatedParty .
+
+ext:allowReadForOrganization a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideOrganizationSlice ; # NOTE (24/03/2026): Singular organization
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:organizationMemberParty .
+
+ext:allowReadForOsloOrganizations a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideOsloOrganizationsSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForAiSlice a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideAiSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForHumanValidation a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHumanValidationSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowWriteForHumanValidation a odrl:Permission ;
+  odrl:action odrl:modify ;
+  odrl:target ext:decideHumanValidationSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadAnnotationForPublic a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decidePublicSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadAnnotationForGhent a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedGentSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadAnnotationForFreiburg a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedFreiburgSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadAnnotationForPdf a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedPdfSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowAnnotationReadForAiSlice a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideAiSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+# Assets (SHACL shapes) for type specifications
+ext:BesluitAdministrativeUnitAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideOsloOrganizationsSlice;
+  sh:targetClass besluit:Bestuurseenheid .
+
+ext:CmsPageAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass cms:Page .
+
+ext:DcatCatalogAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingSlice ;
+  sh:targetClass dcat:Catalog .
+
+ext:DcatDatasetAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingSlice ;
+  sh:targetClass dcat:Dataset .
+
+ext:DcatDistributionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingSlice ;
+  sh:targetClass dcat:Distribution .
+
+ext:DctMediaTypeOrExtentAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass dct:MediaTypeOrExtent .
+
+ext:DctPeriodOfTimeAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass dct:PeriodOfTime .
+
+ext:ElidlActivityAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingPublicSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass eli-dl:Activity .
+
+ext:ElidlDecisionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:Decision .
+
+ext:ElidlDraftLegislationWorkAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:DraftLegislationWork .
+
+ext:ElidlForeseenActivityAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:ForeseenActivity .
+
+ext:ElidlLegislativeProcessAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:LegislativeProcess .
+
+ext:ElidlLegislativeProcessWorkAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:LegislativeProcessWork .
+
+ext:ElidlParliamentaryTermAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:ParliamentaryTerm .
+
+ext:ElidlParticipationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:Participation .
+
+ext:ElidlProcessStageAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:ProcessStage .
+
+ext:ElidlVoteAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:Vote .
+
+ext:EliComplexWorkAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli:ComplexWork .
+
+ext:EliExpressionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingPublicSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass eli:Expression .
+
+ext:EliLegalExpressionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingPublicSlice ;
+  sh:targetClass eli:LegalExpression .
+
+ext:EliManifestationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingPublicSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass eli:Manifestation .
+
+ext:EliWorkAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass eli:Work .
+
+ext:FoafAgentAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass foaf:Agent .
+
+ext:FoafPersonAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideOrganizationSlice ;
+  sh:targetClass foaf:Person .
+
+ext:FoafOnlineAccountAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideOrganizationSlice ;
+  sh:targetClass foaf:OnlineAccount .
+
+ext:AdmsIdentifierAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideOrganizationSlice ;
+  sh:targetClass adms:Identifier .
+
+ext:OparltempLocationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass oparl-temp:Location .
+
+ext:OrgMembershipAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass org:Membership .
+
+ext:OrgOrganizationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideOrganizationsSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass org:Organization .
+
+ext:SkosConceptAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass skos:Concept .
+
+ext:SkosConceptSchemeAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass skos:ConceptScheme .
+
+ext:DctLocationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass dct:Location .
+
+ext:LocnGeometryAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass locn:Geometry .
+
+ext:LocnAddressAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass locn:Address .
+
+ext:SchemaTouristAttractionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass schema:TouristAttraction .
+
+ext:PerceelPerceelAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass perceel:Perceel .
+
+ext:WikidataQ2785216Asset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass wikidata:Q2785216 .
+
+ext:OaAnnotationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideAiSlice ;
+  sh:targetClass oa:Annotation .
+
+ext:OaSpecificResourceAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideAiSlice ;
+  sh:targetClass oa:SpecificResource .
+
+ext:OaTextPositionSelectorAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideAiSlice ;
+  sh:targetClass oa:TextPositionSelector .
+
+ext:TasksTaskAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass tasks:Task .
+
+ext:TasksScheduledTaskAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass tasks:ScheduledTask .
+
+ext:TasksCronScheduleAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass tasks:CronSchedule .
+
+ext:CogsJobAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass cogs:Job .
+
+ext:ExtAnnotionJobAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass ext:AnnotationJob .
+
+ext:ExtReviewAnnotationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHumanValidationSlice ;
+  sh:targetClass ext:ReviewAnnotation .
+
+ext:NodeShapeAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass sh:NodeShape .
+
+ext:CogsScheduledJobAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass cogs:ScheduledJob .
+
+ext:SchemaRepeatFrequencyAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass schema:repeatFrequency .
+
+ext:CoreErrorAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass core:Error .
+
+ext:HarvestingHarvestingCollectionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass harvesting:HarvestingCollection .
+
+ext:NfoRemoteDataObjectAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decideHarvestingPublicSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass nfo:RemoteDataObject .
+
+ext:NfoFileDataObjectAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decideHarvestingPublicSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass nfo:FileDataObject .
+
+ext:NfoDataContainerAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass nfo:DataContainer .
+
+ext:NdoDownloadEventAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass ndo:DownloadEvent .
+
+ext:SecurityAuthenticationConfigurationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass security:AuthenticationConfiguration .
+
+ext:SecurityCredentialsAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass security:Credentials .
+
+ext:SecurityBasicAuthenticationCredentialsAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass security:BasicAuthenticationCredentials .
+
+ext:SecurityOAuth2CredentialsAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass security:OAuth2Credentials .
+
+ext:WotSecuritySchemeAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass wot:SecurityScheme .
+
+ext:WotBasicSecuritySchemeAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass wot:BasicSecurityScheme .
+
+ext:WotOAuth2SecuritySchemeAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass wot:OAuth2SecurityScheme .
+
+# Access rights to the stored copy of this policy itself
+ext:decideAuthzSlice a odrl:AssetCollection ;
+  vcard:fn "odrl-authorization-policy" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/odrl-authorization-policy> .
+
+ext:OdrlProfileAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:Profile .
+
+ext:OdrlPartyAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:Party .
+
+ext:OdrlPartyCollectionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:PartyCollection .
+
+ext:OdrlAssetCollectionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:AssetCollection .
+
+ext:OdrlAssetAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:Asset .
+
+ext:OdrlPermissionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:Permission .
+
+ext:allowPublicReadForAuthz a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideAuthzSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .


### PR DESCRIPTION
Insert the app's authorization policy into the triplestore and the data publicly readable.

A migration inserts the data into a new graph, `http://mu.semte.ch/graphs/odrl-authorization-policy`, to keep it separate from other data and to make any future updates easier.
The sparql-parser configuration is extended with entities covering the different resources types in an ODRL authorization policy (i.e. itself). Note, there was already an asset defined for SHACL node shapes, so this was reused.

## How to test
0. Checkout the branch of this PR
1. Restart the `database` service to load the updated policy
2. Restart the `migrations` service to execute the added migration
3. Browse to the yasgui frontend's mock-login and login: `http://yasgui.localhost/mock-login`
4. Querying for data for ODRL data should give as results the data in the authorization policy. For example, the following query should list all triples for the defined ODRL asset collections.

``` sparql
PREFIX odrl: <http://www.w3.org/ns/odrl/2/>
SELECT DISTINCT ?s ?p ?o
WHERE {
  ?s a odrl:AssetCollection ;
    ?p ?o .
}
```

## Related tickets
- LBRON-1459