### PR TITLE
add example migration for the non-public sparql endpoint

### DIFF
--- a/config/migrations/20260519091850-add-private-dataset.graph
+++ b/config/migrations/20260519091850-add-private-dataset.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20260519091850-add-private-dataset.ttl
+++ b/config/migrations/20260519091850-add-private-dataset.ttl
@@ -1,0 +1,75 @@
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .  
+@prefix dcat: <http://www.w3.org/ns/dcat#> .  
+@prefix dct: <http://purl.org/dc/terms/> .  
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .  
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .  
+@prefix schema: <https://schema.org/> .  
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix private-ds-ex: <http://decide.data.gift/datasets/example/60e19fdf-b549-41b9-9adf-420379285127/> .
+@prefix public-ds-ex: <http://decide.data.gift/datasets/example/1ae2da8e-9889-426b-a7e8-9360c15ba2cd/> .
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+
+public-ds-ex:dataset a dcat:Dataset ;  
+    mu:uuid "1ae2da8e-9889-426b-a7e8-9360c15ba2cd" ;
+    dct:title "Licensed Dataset" ;  
+    dct:description "An example dataset available only to users who purchased a valid license." ;  
+    dcat:distribution public-ds-ex:distribution .
+
+public-ds-ex:distribution a dcat:Distribution ;  
+    mu:uuid "12f78fc1-9292-48fd-8c91-e835578dfcf3" ;
+    dct:format "application/sparql-query" ;  
+    dcat:accessURL <https://ds.decide.lblod.info/api/sparql> .
+
+public-ds-ex:policy a odrl:Agreement, ext:PublicPolicy ;  
+    mu:uuid "ab4509a9-4676-4966-bc07-8c20a3eb1d80" ;
+    dct:description "Anyone may use this dataset" ;
+    odrl:target public-ds-ex:dataset ;  
+    odrl:assigner <http://ds.decide.lblod.info> ;  
+    odrl:permission [  
+        odrl:action odrl:use ;  
+    ].
+
+
+private-ds-ex:dataset a dcat:Dataset ;  
+    mu:uuid "60e19fdf-b549-41b9-9adf-420379285127" ;
+    dct:title "Licensed Dataset" ;  
+    dct:description "An example dataset available only to users who purchased a valid license." ;  
+    dcat:distribution private-ds-ex:distribution .
+
+private-ds-ex:distribution a dcat:Distribution ;  
+    mu:uuid "341bc1ef-f4ab-4450-80af-b72d7c682e7f" ;
+    dct:format "application/sparql-query" ;  
+    dcat:accessURL <https://ds.decide.lblod.info/api/private/sparql> .
+
+private-ds-ex:policy a odrl:Agreement, ext:RestrictedPolicy ;  
+    mu:uuid "1d8e1e34-ac8c-4fb8-845a-a9e8ca0e9f6b" ;
+    dct: "Only licensed users may access this content" ;
+    odrl:conflict odrl:perm ;
+    odrl:assigner <http://ds.decide.lblod.info> ;  
+    odrl:target private-ds-ex:dataset ;  
+    odrl:permission [  
+        odrl:action odrl:use ;  
+        odrl:assignee private-ds-ex:licensedUserCollection ;  
+    ] ;
+    odrl:prohibition [  
+        odrl:action odrl:use ;  
+    ].
+
+# PartyCollection listing the users with a license
+private-ds-ex:licensedUserCollection a odrl:PartyCollection ;  
+    mu:uuid "e17ce5aa-d56f-48b6-bff0-c5440d2fd9ab" ;
+    dct:description "Collection of users or organizations who have purchased a valid license for the dataset." ;  
+    dct:relation private-ds-ex:licenseOffering . 
+
+# How to obtain the license, url still to be determined
+private-ds-ex:licenseOffering a schema:Offer ;  
+    mu:uuid "982416d7-5702-41fe-a08a-9f28542e5c82" ;
+    schema:name "Dataset Access License" ;  
+    schema:description "A license granting access to the licensed dataset." ;  
+    schema:url <http://ds.decide.lblod.info/licenses/purchase> ;
+    schema:howTo [  
+        schema:name "How to Obtain a License" ;  
+        schema:description "Visit the license purchase page and complete the checkout process. API access is also available for automated licensing." ;  
+        schema:url <http://ds.decide.lblod.info/licenses/purchase> ;
+    ] .

--- a/config/migrations/20260519091850-add-private-dataset.ttl
+++ b/config/migrations/20260519091850-add-private-dataset.ttl
@@ -27,8 +27,11 @@ public-ds-ex:policy a odrl:Offer, ext:PublicPolicy ;
     odrl:target public-ds-ex:dataset ;  
     odrl:assigner <http://ds.decide.lblod.info> ;  
     odrl:permission [  
-        odrl:action odrl:use ;  
-    ].
+        odrl:action odrl:read ;  
+    ] ;
+    odrl:prohibition [
+      odrl:action odrl:write ;
+    ] .
 
 
 private-ds-ex:dataset a dcat:Dataset ;  
@@ -49,12 +52,12 @@ private-ds-ex:policy a odrl:Offer, ext:RestrictedPolicy ;
     odrl:assigner <http://ds.decide.lblod.info> ;  
     odrl:target private-ds-ex:dataset ;  
     odrl:permission [  
-        odrl:action odrl:use ;  
+        odrl:action odrl:read ;  
         odrl:assignee private-ds-ex:licensedUserCollection ;  
     ] ;
     odrl:prohibition [  
-        odrl:action odrl:use ;  
-    ].
+        odrl:action odrl:read, odrl:write ;  
+    ] .
 
 # PartyCollection listing the users with a license
 private-ds-ex:licensedUserCollection a odrl:PartyCollection ;  

--- a/config/migrations/20260519091850-add-private-dataset.ttl
+++ b/config/migrations/20260519091850-add-private-dataset.ttl
@@ -71,7 +71,7 @@ private-ds-ex:licenseOffering a schema:Offer ;
     schema:name "Dataset Access License" ;  
     schema:description "A license granting access to the licensed dataset." ;  
     schema:url <http://ds.decide.lblod.info/licenses/purchase> ;
-    schema:howTo [  
+    schema:about [  
         schema:name "How to Obtain a License" ;  
         schema:description "Visit the license purchase page and complete the checkout process. API access is also available for automated licensing." ;  
         schema:url <http://ds.decide.lblod.info/licenses/purchase> ;

--- a/config/migrations/20260519091850-add-private-dataset.ttl
+++ b/config/migrations/20260519091850-add-private-dataset.ttl
@@ -12,8 +12,8 @@
 
 public-ds-ex:dataset a dcat:Dataset ;  
     mu:uuid "1ae2da8e-9889-426b-a7e8-9360c15ba2cd" ;
-    dct:title "Licensed Dataset" ;  
-    dct:description "An example dataset available only to users who purchased a valid license." ;  
+    dct:title "Public dataset" ;  
+    dct:description "An example public dataset available any user, even users without a license." ;  
     dcat:distribution public-ds-ex:distribution .
 
 public-ds-ex:distribution a dcat:Distribution ;  
@@ -21,7 +21,7 @@ public-ds-ex:distribution a dcat:Distribution ;
     dct:format "application/sparql-query" ;  
     dcat:accessURL <https://ds.decide.lblod.info/api/sparql> .
 
-public-ds-ex:policy a odrl:Agreement, ext:PublicPolicy ;  
+public-ds-ex:policy a odrl:Offer, ext:PublicPolicy ;  
     mu:uuid "ab4509a9-4676-4966-bc07-8c20a3eb1d80" ;
     dct:description "Anyone may use this dataset" ;
     odrl:target public-ds-ex:dataset ;  
@@ -42,7 +42,7 @@ private-ds-ex:distribution a dcat:Distribution ;
     dct:format "application/sparql-query" ;  
     dcat:accessURL <https://ds.decide.lblod.info/api/private/sparql> .
 
-private-ds-ex:policy a odrl:Agreement, ext:RestrictedPolicy ;  
+private-ds-ex:policy a odrl:Offer, ext:RestrictedPolicy ;  
     mu:uuid "1d8e1e34-ac8c-4fb8-845a-a9e8ca0e9f6b" ;
     dct: "Only licensed users may access this content" ;
     odrl:conflict odrl:perm ;

--- a/config/migrations/20260519091850-add-private-dataset.ttl
+++ b/config/migrations/20260519091850-add-private-dataset.ttl
@@ -24,13 +24,15 @@ public-ds-ex:distribution a dcat:Distribution ;
 public-ds-ex:policy a odrl:Offer, ext:PublicPolicy ;  
     mu:uuid "ab4509a9-4676-4966-bc07-8c20a3eb1d80" ;
     dct:description "Anyone may use this dataset" ;
-    odrl:target public-ds-ex:dataset ;  
-    odrl:assigner <http://ds.decide.lblod.info> ;  
     odrl:permission [  
         odrl:action odrl:read ;  
+        odrl:target public-ds-ex:dataset ;  
+        odrl:assigner <http://ds.decide.lblod.info> ;  
     ] ;
     odrl:prohibition [
       odrl:action odrl:write ;
+      odrl:target public-ds-ex:dataset ;  
+      odrl:assigner <http://ds.decide.lblod.info> ;  
     ] .
 
 
@@ -49,13 +51,15 @@ private-ds-ex:policy a odrl:Offer, ext:RestrictedPolicy ;
     mu:uuid "1d8e1e34-ac8c-4fb8-845a-a9e8ca0e9f6b" ;
     dct: "Only licensed users may access this content" ;
     odrl:conflict odrl:perm ;
-    odrl:assigner <http://ds.decide.lblod.info> ;  
-    odrl:target private-ds-ex:dataset ;  
     odrl:permission [  
+        odrl:assigner <http://ds.decide.lblod.info> ;  
+        odrl:target private-ds-ex:dataset ;  
         odrl:action odrl:read ;  
         odrl:assignee private-ds-ex:licensedUserCollection ;  
     ] ;
     odrl:prohibition [  
+        odrl:assigner <http://ds.decide.lblod.info> ;  
+        odrl:target private-ds-ex:dataset ;  
         odrl:action odrl:read, odrl:write ;  
     ] .
 
@@ -70,9 +74,11 @@ private-ds-ex:licenseOffering a schema:Offer ;
     mu:uuid "982416d7-5702-41fe-a08a-9f28542e5c82" ;
     schema:name "Dataset Access License" ;  
     schema:description "A license granting access to the licensed dataset." ;  
+    schema:url <http://ds.decide.lblod.info/licenses/purchase> .
+
+private-ds-ex:howTo a schema:HowTo ;
+    mu:uuid "c7b6a31a-2418-4927-83de-ad425f2a3988" ;
+    schema:name "How to Obtain a License" ;  
+    schema:description "Visit the license purchase page and complete the checkout process. API access is also available for automated licensing." ;  
     schema:url <http://ds.decide.lblod.info/licenses/purchase> ;
-    schema:about [  
-        schema:name "How to Obtain a License" ;  
-        schema:description "Visit the license purchase page and complete the checkout process. API access is also available for automated licensing." ;  
-        schema:url <http://ds.decide.lblod.info/licenses/purchase> ;
-    ] .
+    schema:about private-ds-ex:licenseOffering .


### PR DESCRIPTION
this adds a migration that describes the (not yet implemented) private sparql endpoint and adds an ODRL policy to it that describes that no one can use it except for members of the licensedUserCollection, which is an odrl:PartyCollection

Non-public datasets can easily be discovered by checking if they are the target of an odrl:Policy that has an odrl:prohibition without odrl:assignee (so default anyone), that forbids the odrl:use action.