### PR TITLE
add dsp-auth-wrapper in preparation for the dsp connector

### DIFF
--- a/compose/data-space.yml
+++ b/compose/data-space.yml
@@ -68,3 +68,11 @@ services:
       - 'logging=true'
     restart: always
     logging: *default-logging
+  dsp-auth-wrapper:
+    image: lblod/decide-dsp-authorization-wrapper:0.0.1
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging
+    environment:
+      DEFAULT_MU_AUTH_SCOPE: http://services.semantic.works/sessions

--- a/config/authorization/config.ttl
+++ b/config/authorization/config.ttl
@@ -33,6 +33,7 @@
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix wikidata: <http://www.wikidata.org/entity/> .
 @prefix wot: <https://www.w3.org/2019/wot/security#> .
+@prefix session: <http://mu.semte.ch/vocabularies/session/> .
 
 ext:muAuthProfile a odrl:Profile ;
   dct:description "ODRL profile describing access to mu-auth resources." .
@@ -57,6 +58,10 @@ ext:decideAuthorizationPolicy a odrl:Set ;
     ext:allowReadAnnotationForFreiburg ,
     ext:allowReadAnnotationForPdf ,
     ext:allowAnnotationReadForAiSlice ,
+    ext:allowReadForSession ,
+    ext:allowWriteForSession ,
+    ext:allowReadPublicForSession ,
+    ext:allowReadOrgsForSession ,
     ext:allowPublicReadForAuthz .
 
 # Parties for groups
@@ -67,6 +72,10 @@ ext:decideSystem a odrl:Party ;
 ext:publicParty a odrl:PartyCollection ;
   vcard:fn "public" ;
   dct:description "This party represent all (possibly not logged in) users of the system." .
+
+ext:sessionService a odrl:PartyCollection ;
+  vcard:fn "session service" ;
+  dct:description "This party represent all session services running in the system." .
 
 ext:authenticatedParty a odrl:PartyCollection ;
   vcard:fn "logged-in" ;
@@ -129,6 +138,10 @@ ext:decidePublicSlice a odrl:AssetCollection ;
 ext:decideHumanValidationSlice a odrl:AssetCollection ;
   vcard:fn "human-validation" ;
   ext:graphPrefix <http://mu.semte.ch/graphs/public/human-validation> .
+
+ext:decideSessionSlice a odrl:AssetCollection ;
+  vcard:fn "session information" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/sessions> .
 
 ext:decideAiSlice a odrl:AssetCollection ;
   vcard:fn "ai" ;
@@ -194,6 +207,32 @@ ext:allowReadForAiSlice a odrl:Permission ;
   odrl:target ext:decideAiSlice ;
   odrl:assigner ext:decideSystem ;
   odrl:assignee ext:publicParty .
+
+ext:allowReadForSession a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideSessionSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/sessions" .
+
+ext:allowWriteForSession a odrl:Permission ;
+  odrl:action odrl:write ;
+  odrl:target ext:decideSessionSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/sessions" .
+
+ext:allowReadPublicForSession a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decidePublicSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/sessions" .
+
+ext:allowReadOrgsForSession a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideOsloOrganizationsSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/sessions" .
 
 ext:allowReadForHumanValidation a odrl:Permission ;
   odrl:action odrl:read ;
@@ -435,6 +474,10 @@ ext:OaTextPositionSelectorAsset a odrl:Asset, sh:NodeShape ;
   odrl:partOf ext:decidePublicSlice ,
     ext:decideAiSlice ;
   sh:targetClass oa:TextPositionSelector .
+
+ext:SessionAsset a odrl:Asset, sh:NodeSchape ;
+  odrl:partOf ext:decideSessionSlice ;
+  sh:targetClass session:Session .
 
 ext:TasksTaskAsset a odrl:Asset, sh:NodeShape ;
   odrl:partOf ext:decideHarvestingSlice ,

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -73,6 +73,10 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://database:8890/sparql"
   end
 
+  match "/api/private/sparql", %{ accept: [:any], layer: :sparql } do
+    Proxy.forward conn, [], "http://dsp-auth-wrapper/sparql"
+  end
+
   match "/annotation-review/*path", %{ accept: [:any], layer: :static } do
     Proxy.forward conn, path, "http://annotation-review/"
   end
@@ -329,7 +333,7 @@ defmodule Dispatcher do
     forward(conn, path, "http://cache/bestuurseenheids/")
   end
 
-  match "/sessions/*path", %{reverse_host: ["dashboard" | _rest]} do
+  match "/sessions/*path", %{layer: :api_services, accept: %{any: true}} do
     Proxy.forward(conn, path, "http://login/sessions/")
   end
 
@@ -345,7 +349,7 @@ defmodule Dispatcher do
     Proxy.forward(conn, path, "http://mocklogin/sessions/")
   end
 
-  match "/sessions/*path", %{layer: :api_services, accept: %{any: true}} do
+  match "/sessions/*path", %{reverse_host: ["ds" | _rest], layer: :api_services, accept: %{any: true}} do
     Proxy.forward(conn, path, "http://acmidm-login/sessions/")
   end
 

--- a/config/migrations/20260526121033-add-example-private-content.sparql
+++ b/config/migrations/20260526121033-add-example-private-content.sparql
@@ -1,0 +1,8 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/organizations/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5/Decide-gebruiker> {
+    <http://data.lblod.info/id/personen/a2d0f0a0-d0c7-4b4d-afce-680184481553> a foaf:Person ;
+      ext:highScore 9001 .
+  }
+}


### PR DESCRIPTION
This add some example content to the restricted graph `<http://mu.semte.ch/graphs/organizations/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5/Decide-gebruiker>` that people can get access to through the VC or the [dsp-auth-wrapper service](https://github.com/lblod/decide-dsp-authorization-wrapper).

It also adds a scope for that service and grants read access to public, the organizations graph and read and write access to the session graph for that service.

When activating this service, one should be able to follow the setup in the dsp-auth-wrapper service to configure a proper api key and then send a sparql query using `POST http://localhost/api/private/sparql`.  When asking for the example data in the private graph, the public sparql endpoint should return an empty resultset, while the private sparql endpoint should return the correct triples.