### PR TITLE
Enable oslo pipeline by default

### DIFF
--- a/compose/pipeline.yml
+++ b/compose/pipeline.yml
@@ -20,6 +20,7 @@ services:
       EMBER_PDF_HARVESTING_ENABLED: true
       EMBER_NER_AND_NEL_ANNOTATIONS_ENABLED: true
       EMBER_CODELIST_MAPPING_ENABLED: true
+      EMBER_OSLO_HARVESTING_ENABLED: true
     labels:
       - 'logging=true'
     restart: always


### PR DESCRIPTION
The OSLO-ELI pipeline wasn't available by default in the harvesting frontend. It is now.