### PR TITLE
chore: bump annotation-job-splitter-service

### DIFF
--- a/compose/pipeline.yml
+++ b/compose/pipeline.yml
@@ -58,7 +58,7 @@ services:
     restart: always
     logging: *default-logging
   annotation-job-splitter:
-    image: lblod/annotation-job-splitter-service:0.0.1
+    image: lblod/annotation-job-splitter-service:0.0.2
     restart: always
     logging: *default-logging
     volumes:


### PR DESCRIPTION
Bumped service to [v0.0.2](https://github.com/lblod/annotation-job-splitter-service/blob/master/CHANGELOG.md#L4)