### PR TITLE
re-enable linking

### DIFF
--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -9,7 +9,7 @@ services:
   # AI PIPELINES
   ##############################################################################
   entity-linking:
-    image: semanticai/entity-linking-backend:0.0.2
+    image: semanticai/entity-linking-backend:0.0.3
     environment:
       TARGET_GRAPH: 'http://mu.semte.ch/graphs/public'
       DEFAULT_GRAPH: 'http://mu.semte.ch/graphs/harvesting'

--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -107,11 +107,14 @@ services:
       - logging=true
   nominatim:
     image: mediagis/nominatim:5.1
-    environment:
-      - PBF_URL=https://download.geofabrik.de/europe/belgium-latest.osm.pbf
     restart: always
+    environment:
+      PBF_PATH: /data/merged.osm.pbf
+      PBF_URL: ''
     volumes:
-      - ./../data/nominatim:/var/lib/postgresql/16/main
+      - ./../data/nominatim/db:/var/lib/postgresql/16/main
+      - ./../data/nominatim/src:/data
+
     logging: *default-logging
     labels:
       - logging=true

--- a/config/annotation-review/config.ts
+++ b/config/annotation-review/config.ts
@@ -252,6 +252,11 @@ export default {
     },
     'http://www.w3.org/ns/org#Organization': {
       name: 'Organization',
+      linkPath: `
+        ?linkerA rdf:subject ?object .
+        ?linkerA rdf:predicate <http://www.w3.org/2004/02/skos/core#exactMatch> .
+        ?linkerA rdf:object ?objectLink .
+      `,
     },
     'http://purl.org/dc/terms/Location': {
       name: 'Location',

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -62,7 +62,7 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/JobType/entity-linking",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/named-entity-linking",
         "nextIndex": "6"
       }
     ]
@@ -97,7 +97,7 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/JobType/entity-linking",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/named-entity-linking",
         "nextIndex": "5"
       }
     ]
@@ -111,7 +111,7 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/JobType/entity-linking",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/named-entity-linking",
         "nextIndex": "1"
       }
     ]

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -140,20 +140,6 @@
       }
     ]
   },
-  "http://lblod.data.gift/id/jobs/concept/JobOperation/eli-entity-linking-test": {
-    "tasksConfiguration": [
-      {
-        "currentOperation": null,
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
-        "nextIndex": "0"
-      },
-      {
-        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-linking",
-        "nextIndex": "1"
-      }
-    ]
-  },
   "http://lblod.data.gift/id/jobs/concept/JobOperation/codelist-matching/training": {
     "tasksConfiguration": [
       {

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -59,6 +59,11 @@
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/segmenting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
         "nextIndex": "5"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/JobType/entity-linking",
+        "nextIndex": "6"
       }
     ]
   },
@@ -89,6 +94,25 @@
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/segmenting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
         "nextIndex": "4"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/JobType/entity-linking",
+        "nextIndex": "5"
+      }
+    ]
+  },
+  "http://lblod.data.gift/id/jobs/concept/JobOperation/nel-annotations": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextIndex": "0"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/JobType/entity-linking",
+        "nextIndex": "1"
       }
     ]
   },


### PR DESCRIPTION
This re-enables the linking step for the pdf pipeline and the ner-and-nel pipeline. It also creates a linking only pipeline.

To create a linking only pipeline you will have to build the harvesting frontend on this pr and use the resulting image in an override: https://github.com/lblod/frontend-harvesting-self-service/pull/62