### PR TITLE
chore: bump version of AI services and remove API keys from the config files

### DIFF
--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -32,7 +32,7 @@ services:
       - ./../data/nel:/app/data
     restart: always
   pdf-scraper:
-    image: semanticai/decide-pdf-scraper:0.0.5
+    image: semanticai/decide-pdf-scraper:0.0.6
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting
@@ -54,7 +54,7 @@ services:
     restart: always
     logging: *default-logging
   pdf-content:
-    image: semanticai/decide-pdf-content-extraction:0.0.11
+    image: semanticai/decide-pdf-content-extraction:0.0.12
     environment:
       APACHE_TIKA_URL: 'http://apache-tika:9998/tika'
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
@@ -116,7 +116,7 @@ services:
     labels:
       - logging=true
   named-entity-recognition:
-    image: semanticai/decide-geocoding-service:0.0.7
+    image: semanticai/decide-geocoding-service:0.0.8
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting
@@ -165,7 +165,7 @@ services:
       - ollama serve & pid=$$! && sleep 5 && ollama pull embeddinggemma && wait $$pid
 
   codelist-labeling:
-    image: semanticai/codelist-labeling-service:0.0.2
+    image: semanticai/codelist-labeling-service:0.0.3
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting

--- a/config/codelist/config.json
+++ b/config/codelist/config.json
@@ -3,7 +3,6 @@
     "provider": "mistralai",
     "model_name": "mistral-small-latest",
     "temperature": 0.1,
-    "api_key": "SECRET_KEY",
     "base_url": "https://api.mistral.ai/v1",
     "timeout": 120
   },

--- a/config/ner/config.json
+++ b/config/ner/config.json
@@ -36,7 +36,6 @@
     "llm": {
       "provider": "mistralai",
       "model_name": "mistral-medium-3.5",
-      "api_key": "SECRET_KEY",
       "base_url": "https://api.mistral.ai/v1",
       "temperature": 0.1
     },

--- a/config/pdf-content/config.json
+++ b/config/pdf-content/config.json
@@ -12,7 +12,6 @@
   },
   "segmentation": {
     "model_name": "mistral-medium-3.5",
-    "api_key": "SECRET_KEY",
     "endpoint": "https://api.mistral.ai/v1",
     "max_new_tokens": 250000,
     "text_limit_chars": 1000000,


### PR DESCRIPTION
Bumped AI services to make use of latest AI base service and remove the API keys from the config files of the AI services.