### PR TITLE
chore(doc): update partner guidelines concerning API key configuration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,9 +74,6 @@ This app contains several frontends to which the `dispatcher` service forwards r
 
 
 ### Outsource LLM to the cloud
-> [!WARNING]
-> Currently, API keys have to be configured in (versioned) configuration file per service, as documented in the README of each service. This functionality is being reworked to allow configuring such API keys as environment variables. We will update the service's READMEs as well as the [partner-specific configurations](#partner-configurations) when this functionality is available.
-
 The AI services relying on LLMs by default use local models. But they can also be configured to outsource such computations to external providers in the cloud. This requires at least that you
 
 - obtain the appropriate API keys (or other access tokens) from the providers; and

--- a/docs/docker-compose.override.bamberg.yml
+++ b/docs/docker-compose.override.bamberg.yml
@@ -56,45 +56,38 @@ services:
 
 
   # Configure AI services for UC0.1 and UC2
-  # NOTE (28/05/2026): Currently configuring the API keys for these services as
-  # environment variables is still under development.  The following is a
-  # placeholder that can be used when this functionality is finalised.  Please
-  # consult the README for each individual service for information on how to
-  # configure API keys in the meantime.
   # NOTE: It is advised to set API keys (and other secrets) in a non-versioned
   # `docker-compose.override.yml` to avoid accidentally leaking such secrets.
-  # named-entity-recognition:
-  #   # This service is mostly configured in `../config/ner/config.json`, only
-  #   # secrets are configured as environment variables.
-  #  environment:
-  #    # etranslation
-  #    TRANSLATION__ETRANSLATION__BEARER_TOKEN: "<REPLACE-WITH-TOKEN-IN-OVERRIDE-FILE>"
-  #    TRANSLATION__ETRANSLATION__PASSWORD: "<REPLACE-WITH-PASSWORD-IN-OVERRIDE-FILE>"
-  #    # llm
-  #    LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
-  #    # segmentation
-  #    SEGMENTATION__LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
-  # entity-linking:
-  #   environment:
-  #     LLM_PROVIDER: "<REPLACE-WITH-PROVIDER>"
-  #     # Replace <PROVIDER> with the appropriate name based on the provider set
-  #     # in the previous line. For example, `OPENAI` or `MISTRAL`.
-  #     <PROVIDER>_MODEL: "<REPLACE-WITH-MODEL>"
-  #     <PROVIDER>_API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
-  # codelist-labeling:
-  #   # This service is mostly configured via the file
-  #   # `../config/codelist/config.json`, only secrets are configured as
-  #   # environment variables.
-  #   environment:
-  #     LLM__API_KEY: "SECRET"
-  # question-answering:
-  #   # This service requires you to add appropriate the `langchain-*` packages to
-  #   # its requirements.txt and build the service locally.
-  #   # image: question-answering-local
-  #   environment:
-  #     GENERATION_PROVIDER: "<REPLACE-WITH-PROVIDER>"
-  #     GENERATION_MODEL: "<REPLACE-WITH-MODEL>"
-  #     GENERATION_API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
+  named-entity-recognition:
+    # This service is mostly configured in `../config/ner/config.json`, only
+    # secrets are configured as environment variables.
+   environment:
+     # etranslation
+     TRANSLATION__ETRANSLATION__BEARER_TOKEN: "<REPLACE-WITH-TOKEN-IN-OVERRIDE-FILE>"
+     TRANSLATION__ETRANSLATION__PASSWORD: "<REPLACE-WITH-PASSWORD-IN-OVERRIDE-FILE>"
+     # segmentation
+     SEGMENTATION__LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
+  entity-linking:
+    environment:
+      LLM_PROVIDER: "<REPLACE-WITH-PROVIDER>"
+      # Replace <PROVIDER> with the appropriate name based on the provider set
+      # in the previous line. For example, `OPENAI` or `MISTRAL`.
+      <PROVIDER>_MODEL: "<REPLACE-WITH-MODEL>"
+      <PROVIDER>_API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
+  codelist-labeling:
+    # This service is mostly configured via the file
+    # `../config/codelist/config.json`, only secrets are configured as
+    # environment variables.
+    environment:
+      LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
+  question-answering:
+    # This service requires you to add appropriate the `langchain-*` packages to
+    # its requirements.txt and build the service locally.
+    # image: question-answering-local
+    environment:
+      GENERATION_PROVIDER: "<REPLACE-WITH-PROVIDER>"
+      GENERATION_MODEL: "<REPLACE-WITH-MODEL>"
+      GENERATION_API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
 
 
   # Uncomment to disable the services related to the Human validation interface

--- a/docs/docker-compose.override.freiburg.yml
+++ b/docs/docker-compose.override.freiburg.yml
@@ -48,39 +48,32 @@ services:
     entrypoint: ["echo", "Service frontend-policy-impact-report is disabled"]
 
   # Configure services for UC1 Restrictive Mobility Zones
-  # NOTE (28/05/2026): Currently configuring the API keys for these services as
-  # environment variables is still under development.  The following is a
-  # placeholder that can be used when this functionality is finalised.  Please
-  # consult the README for each individual service for information on how to
-  # configure API keys in the meantime.
   # NOTE: It is advised to set API keys (and other secrets) in a non-versioned
   # `docker-compose.override.yml` to avoid accidentally leaking such secrets.
-  # codelist-labeling:
-  #   # This service is mostly configured via the file
-  #   # `../config/codelist/config.json`, only secrets are configured as
-  #   # environment variables.
-  #   environment:
-  #     LLM__API_KEY: "SECRET"
-  # named-entity-recognition:
-  #   # This service is mostly configured in `../config/ner/config.json`, only
-  #   # secrets are configured as environment variables.
-  #  environment:
-  #    # etranslation
-  #    TRANSLATION__ETRANSLATION__BEARER_TOKEN: "<REPLACE-WITH-TOKEN-IN-OVERRIDE-FILE>"
-  #    TRANSLATION__ETRANSLATION__PASSWORD: "<REPLACE-WITH-PASSWORD-IN-OVERRIDE-FILE>"
-  #    # llm
-  #    LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
-  #    # segmentation
-  #    SEGMENTATION__LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
-  # nominatim:
-  #   environment:
-  #     # Retrieve OSM data extracts for Germany instead of Belgium, as configured
-  #     # by default.
-  #     PBF_URL: https://download.geofabrik.de/europe/germany-latest.osm.pbf
-  #     # How many threads should be used to import (default: number of processing
-  #     # units available to the current process via nproc)
-  #     # Source: https://github.com/mediagis/nominatim-docker/blob/master/howto.md#configuration
-  #     # THREADS: 20
+  named-entity-recognition:
+    # This service is mostly configured in `../config/ner/config.json`, only
+    # secrets are configured as environment variables.
+   environment:
+     # etranslation
+     TRANSLATION__ETRANSLATION__BEARER_TOKEN: "<REPLACE-WITH-TOKEN-IN-OVERRIDE-FILE>"
+     TRANSLATION__ETRANSLATION__PASSWORD: "<REPLACE-WITH-PASSWORD-IN-OVERRIDE-FILE>"
+     # segmentation
+     SEGMENTATION__LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
+  codelist-labeling:
+    # This service is mostly configured via the file
+    # `../config/codelist/config.json`, only secrets are configured as
+    # environment variables.
+    environment:
+      LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
+  nominatim:
+    environment:
+      # Retrieve OSM data extracts for Germany instead of Belgium, as configured
+      # by default.
+      PBF_URL: https://download.geofabrik.de/europe/germany-latest.osm.pbf
+      # How many threads should be used to import (default: number of processing
+      # units available to the current process via nproc)
+      # Source: https://github.com/mediagis/nominatim-docker/blob/master/howto.md#configuration
+      # THREADS: 20
 
   # Disable services for UC2 smart search
   search:

--- a/docs/docker-compose.override.ghent.yml
+++ b/docs/docker-compose.override.ghent.yml
@@ -42,45 +42,38 @@ services:
     entrypoint: ["echo", "Service harvest_diff is disabled"]
 
   # Configure AI services for UC0.1 and UC2
-  # NOTE (28/05/2026): Currently configuring the API keys for these services as
-  # environment variables is still under development.  The following is a
-  # placeholder that can be used when this functionality is finalised.  Please
-  # consult the README for each individual service for information on how to
-  # configure API keys in the meantime.
   # NOTE: It is advised to set API keys (and other secrets) in a non-versioned
   # `docker-compose.override.yml` to avoid accidentally leaking such secrets.
-  # named-entity-recognition:
-  #   # This service is mostly configured in `../config/ner/config.json`, only
-  #   # secrets are configured as environment variables.
-  #  environment:
-  #    # etranslation
-  #    TRANSLATION__ETRANSLATION__BEARER_TOKEN: "<REPLACE-WITH-TOKEN-IN-OVERRIDE-FILE>"
-  #    TRANSLATION__ETRANSLATION__PASSWORD: "<REPLACE-WITH-PASSWORD-IN-OVERRIDE-FILE>"
-  #    # llm
-  #    LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
-  #    # segmentation
-  #    SEGMENTATION__LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
-  # entity-linking:
-  #   environment:
-  #     LLM_PROVIDER: "<REPLACE-WITH-PROVIDER>"
-  #     # Replace <PROVIDER> with the appropriate name based on the provider set
-  #     # in the previous line. For example, `OPENAI` or `MISTRAL`.
-  #     <PROVIDER>_MODEL: "<REPLACE-WITH-MODEL>"
-  #     <PROVIDER>_API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
-  # codelist-labeling:
-  #   # This service is mostly configured via the file
-  #   # `../config/codelist/config.json`, only secrets are configured as
-  #   # environment variables.
-  #   environment:
-  #     LLM__API_KEY: "SECRET"
-  # question-answering:
-  #   # This service requires you to add appropriate the `langchain-*` packages to
-  #   # its requirements.txt and build the service locally.
-  #   # image: question-answering-local
-  #   environment:
-  #     GENERATION_PROVIDER: "<REPLACE-WITH-PROVIDER>"
-  #     GENERATION_MODEL: "<REPLACE-WITH-MODEL>"
-  #     GENERATION_API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
+  named-entity-recognition:
+    # This service is mostly configured in `../config/ner/config.json`, only
+    # secrets are configured as environment variables.
+   environment:
+     # etranslation
+     TRANSLATION__ETRANSLATION__BEARER_TOKEN: "<REPLACE-WITH-TOKEN-IN-OVERRIDE-FILE>"
+     TRANSLATION__ETRANSLATION__PASSWORD: "<REPLACE-WITH-PASSWORD-IN-OVERRIDE-FILE>"
+     # segmentation
+     SEGMENTATION__LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
+  entity-linking:
+    environment:
+      LLM_PROVIDER: "<REPLACE-WITH-PROVIDER>"
+      # Replace <PROVIDER> with the appropriate name based on the provider set
+      # in the previous line. For example, `OPENAI` or `MISTRAL`.
+      <PROVIDER>_MODEL: "<REPLACE-WITH-MODEL>"
+      <PROVIDER>_API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
+  codelist-labeling:
+    # This service is mostly configured via the file
+    # `../config/codelist/config.json`, only secrets are configured as
+    # environment variables.
+    environment:
+      LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
+  question-answering:
+    # This service requires you to add appropriate the `langchain-*` packages to
+    # its requirements.txt and build the service locally.
+    # image: question-answering-local
+    environment:
+      GENERATION_PROVIDER: "<REPLACE-WITH-PROVIDER>"
+      GENERATION_MODEL: "<REPLACE-WITH-MODEL>"
+      GENERATION_API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
 
   # Uncomment to disable the services related to the Human validation interface
   # Alternatively, comment the validation.yml line in `docker-compose.yml`


### PR DESCRIPTION
Following [#121](https://github.com/lblod/app-decide/pull/121) this PR updates the partner guidelines to
- remove the warnings concerning configuring API keys in versioned config files; and
- uncomments the example docker compose override entries that the partners can use to configure their app isntance.