### PR TITLE
Added authorization config for question-answering service

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ To include (smart) search features, the stack needs to be started with the `sear
 
 However, to avoid issues of started services waiting for the database and/or elasticsearch, it is advisable to start the stack in a 'staggered' manner:
 
+To reset the elasticsearch index, first throw away the current `elasticsearch` directory:
+```
+rm -rf data/elasticsearch
+```
+
 ```bash
 docker compose --profile=search up -d virtuoso migrations
 docker compose --profile=search up -d database identifier dispatcher resource
@@ -111,7 +116,7 @@ docker compose logs -f embedding
 Finally, you can start the remaining services of the stack:
 
 ```bash
-docker compose --profile-search up -d
+docker compose --profile=search up -d
 ```
 
 The frontend for the Smart Search should now be available at http://smart-search.localhost .

--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -102,6 +102,7 @@ services:
       MAX_CONTENT_CHARS: '1000'
       REQUEST_TIMEOUT: '10.0'
       ALLOW_MU_AUTH_SUDO: 'true'
+      DEFAULT_MU_AUTH_SCOPE: 'http://services.semantic.works/decide-question-answering-service'
     restart: always
     logging: *default-logging
     labels:
@@ -193,4 +194,3 @@ services:
     logging: *default-logging
     volumes:
       - ./../config/codelist/config.json:/usr/src/app/config.json:ro # Mount config as read-only
-

--- a/config/authorization/config.ttl
+++ b/config/authorization/config.ttl
@@ -53,6 +53,8 @@ ext:decideAuthorizationPolicy a odrl:Set ;
     ext:allowReadOsloOrgsForHumanValidation ,
     ext:allowReadForHumanValidation ,
     ext:allowWriteForHumanValidation ,
+    ext:allowReadForQuestionAnswering ,
+    ext:allowWriteForQuestionAnswering ,
     ext:allowReadAnnotationForPublic ,
     ext:allowReadAnnotationForGhent ,
     ext:allowReadAnnotationForFreiburg ,
@@ -138,6 +140,10 @@ ext:decidePublicSlice a odrl:AssetCollection ;
 ext:decideHumanValidationSlice a odrl:AssetCollection ;
   vcard:fn "human-validation" ;
   ext:graphPrefix <http://mu.semte.ch/graphs/public/human-validation> .
+
+ext:decideQuestionAnsweringSlice a odrl:AssetCollection ;
+  vcard:fn "question-answering" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/public/question-answering> .
 
 ext:decideSessionSlice a odrl:AssetCollection ;
   vcard:fn "session information" ;
@@ -247,6 +253,20 @@ ext:allowWriteForHumanValidation a odrl:Permission ;
   odrl:assigner ext:decideSystem ;
   odrl:assignee ext:publicParty ;
   ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadForQuestionAnswering a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideQuestionAnsweringSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/decide-question-answering-service" .
+
+ext:allowWriteForQuestionAnswering a odrl:Permission ;
+  odrl:action odrl:modify ;
+  odrl:target ext:decideQuestionAnsweringSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/decide-question-answering-service" .
 
 ext:allowReadOsloOrgsForHumanValidation a odrl:Permission ;
   odrl:action odrl:read ;
@@ -506,6 +526,21 @@ ext:ExtAnnotionJobAsset a odrl:Asset, sh:NodeShape ;
 ext:ExtReviewAnnotationAsset a odrl:Asset, sh:NodeShape ;
   odrl:partOf ext:decideHumanValidationSlice ;
   sh:targetClass ext:ReviewAnnotation .
+
+ext:SchemaQuestionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideQuestionAnsweringSlice ,
+    ext:decideAiSlice ;
+  sh:targetClass schema:Question .
+
+ext:SchemaAnswerAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideQuestionAnsweringSlice ,
+    ext:decideAiSlice ;
+  sh:targetClass schema:Answer .
+
+ext:SchemaQuotationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideQuestionAnsweringSlice ,
+    ext:decideAiSlice ;
+  sh:targetClass schema:Quotation .
 
 ext:NodeShapeAsset a odrl:Asset, sh:NodeShape ;
   odrl:partOf ext:decideHarvestingSlice ,

--- a/config/authorization/decide.lisp
+++ b/config/authorization/decide.lisp
@@ -158,7 +158,7 @@
 (define-graph ai ("http://mu.semte.ch/graphs/ai")
   ("oa:Annotation" -> _)
   ("oa:SpecificResource" -> _)
-  ("oa:TextPositionSelector" -> _)
+  ("oa:TextPositionSelector" -> _))
 
 (supply-allowed-group "public")
 

--- a/config/authorization/decide.lisp
+++ b/config/authorization/decide.lisp
@@ -150,10 +150,15 @@
 (define-graph human-validation ("http://mu.semte.ch/graphs/public/human-validation")
   ("ext:ReviewAnnotation" -> _))
 
+(define-graph question-answering ("http://mu.semte.ch/graphs/public/question-answering")
+  ("schema:Question" -> _)
+  ("schema:Answer" -> _)
+  ("schema:Quotation" -> _))
+
 (define-graph ai ("http://mu.semte.ch/graphs/ai")
   ("oa:Annotation" -> _)
   ("oa:SpecificResource" -> _)
-  ("oa:TextPositionSelector" -> _))
+  ("oa:TextPositionSelector" -> _)
 
 (supply-allowed-group "public")
 
@@ -211,6 +216,21 @@
     :for-allowed-group "public"))
 
 (with-scope "http://services.semantic.works/annotation-review-service"
+  (grant (read)
+    :to-graph ai
+    :for-allowed-group "public"))
+
+(with-scope "http://services.semantic.works/decide-question-answering-service"
+  (grant (read write)
+    :to-graph question-answering
+    :for-allowed-group "public"))
+
+(with-scope "http://services.semantic.works/decide-question-answering-service"
+  (grant (read)
+    :to-graph public
+    :for-allowed-group "public"))
+
+(with-scope "http://services.semantic.works/decide-question-answering-service"
   (grant (read)
     :to-graph ai
     :for-allowed-group "public"))


### PR DESCRIPTION
This addition was needed to store the questions and answers in the triplestore.

Related PRs:
- https://github.com/semantic-ai/decide-question-answering/pull/9