### PR TITLE
Add mock data for showcasing restricted access to datasets

### DIFF
--- a/config/migrations/add-mock-data/20260609133200-add-private-mock-expressions.sparql
+++ b/config/migrations/add-mock-data/20260609133200-add-private-mock-expressions.sparql
@@ -1,0 +1,48 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX eli: <http://data.europa.eu/eli/ontology#>
+PREFIX epvoc: <https://data.europarl.europa.eu/def/epvoc#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+INSERT DATA {
+
+    GRAPH <http://mu.semte.ch/graphs/organizations/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5/Decide-gebruiker> {
+
+        <http://data.lblod.info/id/works/348bba93-d3eb-49b9-9d03-3e056b72cfda>
+            a eli:Work ;
+            mu:uuid "348bba93-d3eb-49b9-9d03-3e056b72cfda" ;
+            dct:identifier "TEST-GENT-001" ;
+            dct:title "Test besluit Gent"@nl ;
+            eli:date_document "2026-06-09"^^xsd:date ;
+            dct:creator <http://data.lblod.info/id/bestuurseenheden/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5> ;
+            eli:passed_by <http://data.lblod.info/id/bestuurseenheden/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5> ;
+            eli:is_realized_by <http://data.lblod.info/id/expressions/d06a2c07-07fa-4330-9e35-b1734a054824> .
+
+        <http://data.lblod.info/id/expressions/d06a2c07-07fa-4330-9e35-b1734a054824>
+            a eli:Expression ;
+            mu:uuid "d06a2c07-07fa-4330-9e35-b1734a054824" ;
+            eli:title "Test besluit Gent"@nl ;
+            eli:language <http://publications.europa.eu/resource/authority/language/NLD> ;
+            epvoc:expressionContent "Lorem ipsum dolor sit amet. (Test - Gent)"@nl .
+    }
+
+    GRAPH <http://mu.semte.ch/graphs/organizations/c8e6b8ef-0a33-425a-b9d5-96354823f6e7/Decide-gebruiker> {
+
+        <http://data.lblod.info/id/works/b2d3553b-12a3-4d77-a7c5-1512885b3542>
+            a eli:Work ;
+            mu:uuid "b2d3553b-12a3-4d77-a7c5-1512885b3542" ;
+            dct:identifier "TEST-BAMBERG-001" ;
+            dct:title "Testbeschluss Bamberg"@de ;
+            eli:date_document "2026-06-09"^^xsd:date ;
+            dct:creator <https://decide.smartcitybamberg.de/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7> ;
+            eli:passed_by <https://decide.smartcitybamberg.de/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7> ;
+            eli:is_realized_by <http://data.lblod.info/id/expressions/08b2a48d-073e-4c39-baa3-78f446211ed3> .
+
+        <http://data.lblod.info/id/expressions/08b2a48d-073e-4c39-baa3-78f446211ed3>
+            a eli:Expression ;
+            mu:uuid "08b2a48d-073e-4c39-baa3-78f446211ed3" ;
+            eli:title "Testbeschluss Bamberg"@de ;
+            eli:language <http://publications.europa.eu/resource/authority/language/DEU> ;
+            epvoc:expressionContent "Lorem ipsum dolor sit amet. (Testdaten - Bamberg)"@de .
+    }
+}


### PR DESCRIPTION
## Description

One of the requirements to be DSP-compliant, is to allow having restricted access to certain datasets. This PR adds some mock decision data under the Ghent and Bamberg graphs (one work and one expression for each) to be able to showcase this functionality in the Decide dataspace.

## How to test

1. Make sure all migrations have run.

2. If not set, configure an api key for the `dsp-auth-wrapper`, e.g. in `docker-compose.override.yml`:

```yml
services:
  dsp-auth-wrapper:
    environment:
      API_KEY: '123'
```

3. Ask the private sparql endpoint for works and expressions, from the point of view of **Ghent**. Check whether the resultset only returns the Ghent and not the Bamberg mock data.

```bash
curl -X POST http://localhost/api/private/sparql \
  -H "Authorization: Bearer 123" \
  -H "dsp-role: http://data.lblod.info/id/bestuurseenheden/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5:bought" \
  --data-urlencode "query=PREFIX dct: <http://purl.org/dc/terms/>
PREFIX eli: <http://data.europa.eu/eli/ontology#>
PREFIX epvoc: <https://data.europarl.europa.eu/def/epvoc#>
SELECT *
WHERE {
  ?work a eli:Work ;
    dct:identifier ?identifier ;
    dct:title ?workTitle ;
    eli:date_document ?dateDocument ;
    dct:creator ?creator ;
    eli:passed_by ?passedBy ;
    eli:is_realized_by ?expression .
  ?expression a eli:Expression ;
    eli:title ?expressionTitle ;
    eli:language ?language ;
    epvoc:expressionContent ?content .
}"
```

4. Ask the private sparql endpoint for works and expressions, from the point of view of **Bamberg**. Check whether the resultset only returns the Bamberg and not the Ghent mock data.

```bash
curl -X POST http://localhost/api/private/sparql \
  -H "Authorization: Bearer 123" \
  -H "dsp-role: https://decide.smartcitybamberg.de/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7:bought" \
  --data-urlencode "query=PREFIX dct: <http://purl.org/dc/terms/>
PREFIX eli: <http://data.europa.eu/eli/ontology#>
PREFIX epvoc: <https://data.europarl.europa.eu/def/epvoc#>
SELECT *
WHERE {
  ?work a eli:Work ;
    dct:identifier ?identifier ;
    dct:title ?workTitle ;
    eli:date_document ?dateDocument ;
    dct:creator ?creator ;
    eli:passed_by ?passedBy ;
    eli:is_realized_by ?expression .
  ?expression a eli:Expression ;
    eli:title ?expressionTitle ;
    eli:language ?language ;
    epvoc:expressionContent ?content .
}"
```