### PR TITLE
allow public read on task info

### DIFF
--- a/config/authorization/config.ttl
+++ b/config/authorization/config.ttl
@@ -45,6 +45,7 @@ ext:decideAuthorizationPolicy a odrl:Set ;
     ext:allowReadForHarvestedFreiburg ,
     ext:allowReadForHarvestedGent ,
     ext:allowReadForHarvestedPdf ,
+    ext:allowReadForHarvestingPublic ,
     ext:allowReadForHarvesting ,
     ext:allowWriteForHarvesting ,
     ext:allowReadForOrganization ,
@@ -183,6 +184,12 @@ ext:allowReadForHarvesting a odrl:Permission ;
   odrl:target ext:decideHarvestingSlice ;
   odrl:assigner ext:decideSystem ;
   odrl:assignee ext:authenticatedParty .
+
+ext:allowReadForHarvestingPublic a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestingSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
 
 ext:allowWriteForHarvesting a odrl:Permission ;
   odrl:action odrl:modify ;

--- a/config/authorization/config.ttl
+++ b/config/authorization/config.ttl
@@ -562,35 +562,6 @@ ext:NdoDownloadEventAsset a odrl:Asset, sh:NodeShape ;
   odrl:partOf ext:decideHarvestingSlice ;
   sh:targetClass ndo:DownloadEvent .
 
-ext:SecurityAuthenticationConfigurationAsset a odrl:Asset, sh:NodeShape ;
-  odrl:partOf ext:decideHarvestingSlice ;
-  sh:targetClass security:AuthenticationConfiguration .
-
-ext:SecurityCredentialsAsset a odrl:Asset, sh:NodeShape ;
-  odrl:partOf ext:decideHarvestingSlice ;
-  sh:targetClass security:Credentials .
-
-ext:SecurityBasicAuthenticationCredentialsAsset a odrl:Asset, sh:NodeShape ;
-  odrl:partOf ext:decideHarvestingSlice ;
-  sh:targetClass security:BasicAuthenticationCredentials .
-
-ext:SecurityOAuth2CredentialsAsset a odrl:Asset, sh:NodeShape ;
-  odrl:partOf ext:decideHarvestingSlice ;
-  sh:targetClass security:OAuth2Credentials .
-
-ext:WotSecuritySchemeAsset a odrl:Asset, sh:NodeShape ;
-  odrl:partOf ext:decideHarvestingSlice ;
-  sh:targetClass wot:SecurityScheme .
-
-ext:WotBasicSecuritySchemeAsset a odrl:Asset, sh:NodeShape ;
-  odrl:partOf ext:decideHarvestingSlice ;
-  sh:targetClass wot:BasicSecurityScheme .
-
-ext:WotOAuth2SecuritySchemeAsset a odrl:Asset, sh:NodeShape ;
-  odrl:partOf ext:decideHarvestingSlice ;
-  sh:targetClass wot:OAuth2SecurityScheme .
-
-
 # Access rights to the stored copy of this policy itself
 ext:decideAuthzSlice a odrl:AssetCollection ;
   vcard:fn "odrl-authorization-policy" ;


### PR DESCRIPTION
the task info should be public as it contains the prov:Activity (task) that generated the content

test by running this query on the sparql endpoint with only public access:

```
 PREFIX rdf:       <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
  PREFIX dct:       <http://purl.org/dc/terms/>
  PREFIX locn:      <http://www.w3.org/ns/locn#>
  PREFIX rdfs:      <http://www.w3.org/2000/01/rdf-schema#>
  PREFIX geosparql: <http://www.opengis.net/ont/geosparql#>
  PREFIX bif:       <bif:>
  PREFIX prov: <http://www.w3.org/ns/prov#>
  PREFIX oa: <http://www.w3.org/ns/oa#>
  PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
  PREFIX eli: <http://data.europa.eu/eli/ontology#>
  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>

  SELECT DISTINCT ?work ?locationLabel ?dist
  WHERE {
    ?task task:operation <http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting> .
    ?task prov:generated / oa:hasBody ?st .
    ?st rdf:subject ?work ;
        rdf:predicate prov:atLocation ;
        rdf:object ?location .

    ?work a eli:Work .
    ?work eli:is_realized_by / ext:owningBody <https://ris.freiburg.de/oparl/body/FR>.

    ?location a dct:Location ;
         rdfs:label ?locationLabel ;
         locn:geometry/geosparql:asWKT ?wkt .

    FILTER(!STRSTARTS(STR(?wkt), "SRID"))

    BIND(
      bif:st_distance(
        ?wkt,
        "POINT(47.996302257057295 7.841421856892811)"^^geosparql:wktLiteral
      ) AS ?dist
    )
  }
  ORDER BY ?dist limit 10
```