### PR TITLE
fix(ldes): correctly apply filters when querying data

### DIFF
--- a/config/ldes-delta-pusher/config.ts
+++ b/config/ldes-delta-pusher/config.ts
@@ -116,7 +116,7 @@ export const streams = {
 };
 
 function getElement(stream, type) {
-  return stream[stream]?.[type];
+  return streams[stream]?.[type];
 }
 
 export function getGraphFilter(stream, type) {

--- a/config/ldes-delta-pusher/config.ts
+++ b/config/ldes-delta-pusher/config.ts
@@ -12,7 +12,22 @@ export const PUBLIC_GRAPH_FILTER = `
 // resource, otherwise the changes will not be picked up.
 const HEALING_PREDICATE = 'http://purl.org/dc/terms/modified';
 
-export const streams = {
+// NOTE (11/06/2026): These type definitions allow the language-server to
+// determine explicit types for functions operating on the `streams` object
+// below.  This simplifies writing such functionality and spotting bugs in it.
+type ResourceConfig = {
+  graphFilter: string;
+  healingPredicates: string[];
+  filter?: string;
+};
+type StreamConfig = {
+  [resourceType: string]: ResourceConfig;
+};
+type LdesConfig = {
+  [streamName: string]: StreamConfig;
+};
+
+export const streams: LdesConfig = {
   public: {
     'http://www.w3.org/ns/dcat#Catalog': {
       graphFilter: PUBLIC_GRAPH_FILTER,
@@ -115,14 +130,14 @@ export const streams = {
   },
 };
 
-function getElement(stream, type) {
+function getElement(stream: string, type: string) {
   return streams[stream]?.[type];
 }
 
-export function getGraphFilter(stream, type) {
+export function getGraphFilter(stream: string, type: string) {
   return getElement(stream, type)?.graphFilter;
 }
 
-export function getFilter(stream, type) {
+export function getFilter(stream: string, type: string) {
   return getElement(stream, type)?.filter;
 }


### PR DESCRIPTION
The `config` for the `ldes-delta-pusher` introduced in #104 contained a small, but impactful, bug.  The helper function `getElement` used to retrieve entries of the `streams` object was lacking an `s` in the variable name.  Consequently, it tried to access a property of its `stream` parameter instead of the `streamS` object defined tin the file.  This causes this function to always return nil.  As a result the `get[Graph]Filter` functions also always return nil. This causes the defined filters not being used in the necessary queries, possibly leading to incorrect resources being added to the feed.


## Proposed solution
Add the missing `s` to `getElements` works correctly again.  Furthermore, I added some explicit type information that make it easier to spot this kind of errors in the future.


## How to reproduce
Add the `fake-data` service as described in the "How to test" section of [#104](https://github.com/lblod/app-decide/pull/104) to your app and use this to insert data into the app.

Specifically, the `/concept-scheme` route is relevant.  The resource inserted by that query has an interesting type, `skos:ConcptScheme`.  But it should be filtered out by the `filter` for that resource type, because it is not linked to `dcat:Catalog` resource.  Before the fix the query executed to retrieve the relevant triples is as below, comments added to clarify what is missing.  This will actually return triples, which are than inserted into the LDES.


``` sparql
SELECT DISTINCT ?s ?p ?o
WHERE {
  # Missing GRAPH FILTER
  GRAPH ?g {
    VALUES ?s {
      <http://mu.semte.ch/vocabularies/ext/SomeConceptScheme>
    }
    ?s ?p ?o .
  }
  # Missing FILTER
}
```


With the fix applied the query becomes, note the filters are now included.  This query returns no results for the added resource.


``` sparql
SELECT DISTINCT ?s ?p ?o
WHERE {
  VALUES ?g {
    <http://mu.semte.ch/graphs/public>
  }
  GRAPH ?g {
    VALUES ?s {
      <http://mu.semte.ch/vocabularies/ext/SomeConceptScheme>
    }
    ?s ?p ?o .
  }

  GRAPH ?g {
    FILTER EXISTS {
      ?catalog <http://www.w3.org/ns/dcat#themeTaxonomy> ?s ;
               a ?type .
      VALUES ?type {
        <http://www.w3.org/ns/dcat#Catalog>
      }
    }
  }
}
```