### PR TITLE
fix(dispatcher): prioritise DCAT frontend over DCAT service

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -8,7 +8,7 @@ defmodule Dispatcher do
     any: ["*/*"]
   ]
 
-  define_layers([:static, :sparql, :api_services, :frontend, :resources, :frontend_fallback, :not_found])
+  define_layers([:static, :sparql, :frontend, :api_services, :resources, :frontend_fallback, :not_found])
 
   options "/*_path", _ do
     conn
@@ -451,7 +451,7 @@ defmodule Dispatcher do
     forward(conn, [], "http://frontend-harvesting/index.html")
   end
 
-  match "/*_path", %{reverse_host: ["ds" | _rest], accept: %{html: true}, layer: :frontend_fallback} do
+  match "/*_path", %{ reverse_host: ["ds" | _rest], accept: %{html: true}, layer: :frontend_fallback } do
     forward(conn, [], "http://frontend-dcat/index.html")
   end
 
@@ -470,11 +470,20 @@ defmodule Dispatcher do
   match "/*_path", %{reverse_host: ["policy-impact-report" | _rest], accept: %{html: true}, layer: :frontend_fallback} do
     forward(conn, [], "http://frontend-policy-impact-report/index.html")
   end
+
   #################
   # DCAT
   #################
+  # NOTE (12/06/2026): This rule ensures requests for the `/dcat` route that
+  # have `text/html` as accept-header are forwarded to the frontend instead of
+  # the service.  Otherwise, requests meant for the frontend are matched by the
+  # rule below and incorrectly forwarded to the service.  The prioritisation is
+  # done by the layers.
+  match "/dcat/*_path", %{ reverse_host: ["ds" | _rest], accept: %{html: true}, layer: :frontend } do
+    forward(conn, [], "http://frontend-dcat/index.html")
+  end
 
-  match "/dcat/*path" do
+  get "/dcat/*path", %{ accept: [:any], layer: :api_services } do
     forward(conn, path, "http://dcat/")
   end
 

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -273,6 +273,15 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/works/"
   end
 
+  # NOTE (12/06/2026): This rule ensures requests for the `/expressions` route that
+  # have `text/html` as accept-header are forwarded to the hvt frontend instead of
+  # to resources.  Otherwise, requests meant for the frontend are matched by the
+  # rule below and incorrectly forwarded to resources.  The prioritisation is
+  # done by the layers.
+  match "/expressions/*_path",  %{reverse_host: ["human-validator" | _rest], accept: [:html], layer: :frontend} do
+    forward(conn, [], "http://frontend-human-validator/index.html")
+  end
+
   match "/expressions/*path", %{ accept: [:json], layer: :resources } do
     Proxy.forward conn, path, "http://cache/expressions/"
   end


### PR DESCRIPTION
The [DCAT frontend](https://github.com/lblod/frontend-decide-dcat) and the [DCAT service](https://github.com/lblod/dcat-service) both provide a `dcat` route.  The dispatcher was configured to prioritise the service for requests for the `dcat` route.  This causes unexpected behaviour in the DCAT frontend.  This PR proposes to fix that by essentially prioritising the frontend over the service for the `dcat` for html requests.


## Proposed solution
We add a second rule for the `/dcat` route and put the original rule in the `api_services` layer.  The new rule is in the, higher priority, `frontend` layer so it be will be tried first.  By limiting the accept types to `text/html` the new rule should only match requests from the frontend.  Requests with explicit, non-wildcard accept-headers will still match the lower-priority `/dcat` rule and be forwarded to the service.

A possible disadvantage is that requests that specify no or `*/*` as accept-header will be forwarded to the frontend.  This might be unexpected behaviour.  For example, when doing `curl http://ds.localhost/dcat/catalogs -H 'Accept: */*'` you now get an HTML response from the frontend instead the JSON-LD response from the service.  To reach the service you now have to explicitly specify a non `text/html` accept-header.  Since the service does not [accept](https://github.com/lblod/dcat-service/blob/master/app.ts#L7-L14) `text/html` anyway, I think this is an acceptable trade-of.


Initially, another solution was attempted to limit the accept-headers for the existing `/dcat` route to those [accepted](https://github.com/lblod/dcat-service/blob/master/app.ts#L7-L14) by the dcat service.  But this does not work as the web browser includes a `*/*` fallback in the accept-header of its requests, causing such requests to still match that rule irrelevant of the specified types.

Note, the `reverse_host` option by itself, does not seem enough to differentiate these routes.  Requests to the `/dcat` route will be match to the rule(s) specifying this path irrelevant whether the `ds` subdomain is used.


## How to reproduce the bug
0. Launch the app (without checking out the proposed fix)
1. Browse to `http://ds.localhost/`, this will redirect you to `http://ds.localhost/dcat/datasets`.  This is the expected behaviour of the frontend.
2. Refresh the page, this wil result in an error `Cannot GET /datasets`.  This is actually the dcat service replying it has no `/datasets` route.
3. Browse to `http://ds.localhost/dcat/catalogs`.  Instead of the expected frontend page you wil get a JSON-LD listing all catalogues.  As before, this is a response from the dcat service, not the frontend.


## How to test
To check whether this fix works:

0. Check out this PR's branch
1. Restart the dispatcher
2. Repeat steps 1-3 from "How to reproduce" above.  This time steps 2 and 3 should result in the expected frontend pages.


To check whether the DCAT service is still reachable.  Perform a request to the `/dcat/catalogs` path with an accept-header other than `text/html` (or `*/*`).  For example:

``` shell
curl 'http://ds.localhost/dcat/catalogs' -H 'Accept: text/turtle'
```