### PR TITLE
Feature/brecht/document validation

### DIFF
--- a/compose/reporting.yml
+++ b/compose/reporting.yml
@@ -5,9 +5,10 @@ x-logging: &default-logging
     max-file: '3'
 services:
   report-generation:
-    image: lblod/loket-report-generation-service:0.8.7
+    image: lblod/loket-report-generation-service:0.8.9
     environment:
       DEFAULT_GRAPH: 'http://mu.semte.ch/graphs/reports'
+      RUN_SPARQL_VALIDATIONS: false
       ONLY_KEEP_LATEST_REPORT: true
       RUN_REPORT_NOW: true
     volumes:

--- a/config/reports/README.md
+++ b/config/reports/README.md
@@ -14,3 +14,11 @@ Content-Type: "application/json"
   }
 }
 ```
+
+# SPARQL-based validation
+
+SPARQL-based validations (defined in `./sparql` folder) can be activated by setting following env variable:
+
+* `RUN_SPARQL_VALIDATIONS` Set to `true`to activate SPARQL validations. Default: `false`
+
+This is disabled by default, because data gets inserted in a temporary graph, which triggers many Delta notifications that trigger other services.

--- a/config/reports/README.md
+++ b/config/reports/README.md
@@ -1,5 +1,28 @@
 # Running
 
+A new validation round is by default started using the cron pattern defined in the `shacl-report.js` file. This is currently set to every night at 3am.
+
+When the service (re)starts and the `RUN_NOW` environment parameter is set to `TRUE`, it automatically starts at start up.
+
+## Adding a new validation
+
+A new validation can be added in two ways:
+
+1) Copy and rename an existing SHACL file in the `shacl` folder and adapt the prefixes, shape URI, target class, and properties
+2) Copy and rename an existing SPARQL-based SHACL file in the `sparql` folder and adapt the prefixes, shape URI, target class, and SPARQL query.
+
+In the `shacl-report.js` configuration file, an array of named graphs is defined where data will be retrieved for validation.
+
+To validate your shape is working properly, following approach can be done:
+1) write test data with a good and bad example to a temporary graph using an INSERT query
+2) add this graph to the named graphs array in `shacl-report.js`
+3) trigger the report (or restart the service) to start a new validation round
+4) The results of the latest report can be found by checking `http://localhost/shacl-reports/shacl-reports/latest/issues`
+
+Inspiration of adding and testing a new SHACL shape can be found in this PR: https://github.com/lblod/app-decide/pull/81
+
+## Manual run
+
 The SHACL validation can be manually triggered using following request:
 
 ```
@@ -15,7 +38,14 @@ Content-Type: "application/json"
 }
 ```
 
-# SPARQL-based validation
+## Environment variables
+
+The following enviroment variables can be configured:
+* `INSERT_BATCH_SIZE`: Number of triples that will be insert per batch. Defaults to `100`.
+* `ONLY_KEEP_LATEST_REPORT`: Boolean that allows, when set to `true`, to only keep the most recent version of a report during its creation and to delete oder versions. Defaults to `false`
+* `RUN_REPORT_NOW`: service automatically starts at start up
+
+## SPARQL-based validation
 
 SPARQL-based validations (defined in `./sparql` folder) can be activated by setting following env variable:
 

--- a/config/reports/shacl-report.js
+++ b/config/reports/shacl-report.js
@@ -26,6 +26,11 @@ export const BATCH_SIZE = env
   .default('100')
   .asIntPositive();
 
+export const RUN_SPARQL_VALIDATIONS = env
+  .get('RUN_SPARQL_VALIDATIONS')
+  .default('false')
+  .asBool();
+  
 import { sparqlEscapeUri, uuid } from "mu";
 import { querySudo } from '@lblod/mu-auth-sudo';
 
@@ -155,12 +160,14 @@ async function validateShapesAndSparql(dataDataset, shapesDataset, sparqlValidat
     const startTime = Date.now();
     console.log(`Running non-SPARQL-based constraints...`);
     const reportDataset = await validateDataset(dataDataset, shapesDataset, reportURI, reportUUID);
-    console.log(`Running SPARQL-based constraints...`);
-    await addSparqlValidationsToReport(
-        dataDataset,
-        reportDataset,
-        sparqlValidationObjects
-    );
+    if (RUN_SPARQL_VALIDATIONS) {
+        console.log(`Running SPARQL-based constraints...`);
+        await addSparqlValidationsToReport(
+            dataDataset,
+            reportDataset,
+            sparqlValidationObjects
+        );
+    }
     const endTime = Date.now();
     console.log(
         `SHACL validation took ${(endTime - startTime) / 1000} seconds.`


### PR DESCRIPTION
We found that running sparql-based validations caused massive delta notifications.
Because the sparql-based validation is rather a PoC showing that is possible, we disable it by default