### PR TITLE
DO NOT MERGE chore(migrations): remove test user account

### DIFF
--- a/config/migrations/20260615111655-remove-test-user.sparql
+++ b/config/migrations/20260615111655-remove-test-user.sparql
@@ -1,0 +1,18 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX people: <http://ext.data.gift/people/>
+PREFIX accounts: <http://ext.data.gift/accounts/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/users> {
+    people:fa46c58c-f94a-4aef-868d-335ec2049a60 ?personP ?personO .
+    accounts:d011deb8-64b8-4497-81df-e32ff19cbdc5 ?accountP ?accountO .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/users> {
+  people:fa46c58c-f94a-4aef-868d-335ec2049a60 a foaf:Person ;
+                                                foaf:account accounts:d011deb8-64b8-4497-81df-e32ff19cbdc5 ;
+                                                ?personP ?personO .
+    accounts:d011deb8-64b8-4497-81df-e32ff19cbdc5 a foaf:OnlineAccount ;
+                                                  ?accountP ?accountO .
+  }
+}


### PR DESCRIPTION
> [!WARNING]
> Do not merge yet.  Given people some time to create their own accounts on the necessary environments, cf. [#135](https://github.com/lblod/app-decide/pull/135)

Remove the default `test` user from app instances where it was previously
inserted.  This disables this account for pipeline dashboard.


## How to test
0. Switch to this PR's branch
1. Restart the migrations service and verify that the added migration executes correctly.
2. Try to login into the dashboard using the `test` account, this should fail now.

## Related tickets
- LBRON-1589
- LBRON-1641