### PR TITLE
conf: enable raw DSL endpoint for UC2 service

### DIFF
--- a/config/search/config.json
+++ b/config/search/config.json
@@ -1,4 +1,5 @@
 {
+  "enable_raw_dsl_endpoint": true,
   "persist_indexes": true,
   "eager_indexing_groups": [[{ "variables": [], "name": "public" }]],
   "automatic_index_updates": true,


### PR DESCRIPTION
The question-answering (RAG) service needs to run a kNN vector search with a city pre-filter bypassing mu-search (and its mu-auth/allowed-groups layer). Enabling the raw-DSL endpoint lets the QA service POST a raw ES query to mu-search's /expressions/search instead.