### PR TITLE
chore(doc): configure base URL for LDES services

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,14 @@ The READMEs for each individual service describes the necessary configuration in
 - The [Embedding](https://github.com/semantic-ai/embedding-service/blob/master/README.md) service currently does not **not** support using an external provider. Embeddings can generated locally without a GPU, but this will take considerable longer.
 
 
+### LDES services (DCAT Federation)
+The LDES services that produce (the data) for an app's LDES feed have to be configured with the proper base URL. The intended value is the base dataspace URL of your application instance with `/ldes/` as affix. For example, for ABB's application instance has `https://ds.decide.lblod.info/` as URL, the base URL for the two LDES services than becomes `https://ds.decide.lblod.info/ldes/`.
+
+Note that the `/ldes/` affix is important as the dispatcher relies on this to forward requests to the `ldes-serve-feed` service. If you use a base URL that does not end in `/ldes/`, you should also update the corresponding dispatcher rule accordingly.
+
+See the configuration for the `ldes-delta-pusher` and `ldes-serve-feed` services in you override file.
+
+
 ### Login for pipeline dashboard
 Using the pipeline dashboard requires you create the appropriate user accounts. The overall [README](../README.md) in this repository describes how to do this in its "Account management for the pipeline dashboard" section.
 

--- a/docs/docker-compose.override.bamberg.yml
+++ b/docs/docker-compose.override.bamberg.yml
@@ -122,6 +122,19 @@ services:
     # This service is used to
     entrypoint: ["echo", "Service nominatim is disabled"]
 
+
+  # LDES services for DCAT federation
+  # Replace the values below to set the base URL used for your app's LDES feed.
+  # Make sure this URL ends with `/ldes/`.
+  ldes-delta-pusher:
+    environment:
+      LDES_BASE: '<REPLACE-WITH-BASE-URL>'
+      # WRITE_INITIAL_STATE: "true"
+  ldes-serve-feed:
+    environment:
+      BASE_URL: '<REPLACE-WITH-BASE-URL>'
+
+
 # Uncomment to configure network exposed by app-letsencrypt
 # networks:
 #   proxy:

--- a/docs/docker-compose.override.freiburg.yml
+++ b/docs/docker-compose.override.freiburg.yml
@@ -118,6 +118,19 @@ services:
     # solution based on Oauth2 and OpenID
     entrypoint: ["echo", "Service acmidm-login is disabled"]
 
+
+  # LDES services for DCAT federation
+  # Replace the values below to set the base URL used for your app's LDES feed.
+  # Make sure this URL ends with `/ldes/`.
+  ldes-delta-pusher:
+    environment:
+      LDES_BASE: '<REPLACE-WITH-BASE-URL>'
+      # WRITE_INITIAL_STATE: "true"
+  ldes-serve-feed:
+    environment:
+      BASE_URL: '<REPLACE-WITH-BASE-URL>'
+
+
 # Uncomment to configure network exposed by app-letsencrypt
 # networks:
 #   proxy:

--- a/docs/docker-compose.override.ghent.yml
+++ b/docs/docker-compose.override.ghent.yml
@@ -104,6 +104,19 @@ services:
     # solution based on Oauth2 and OpenID
     entrypoint: ["echo", "Service acmidm-login is disabled"]
 
+
+  # LDES services for DCAT federation
+  # Replace the values below to set the base URL used for your app's LDES feed.
+  # Make sure this URL ends with `/ldes/`.
+  ldes-delta-pusher:
+    environment:
+      LDES_BASE: "<REPLACE-WITH-BASE-URL>"
+      # WRITE_INITIAL_STATE: "true"
+  ldes-serve-feed:
+    environment:
+      BASE_URL: "<REPLACE-WITH-BASE-URL>"
+
+
 # Uncomment to configure network exposed by app-letsencrypt
 # networks:
 #   proxy:


### PR DESCRIPTION
Document what partners need to do to configured the base URL for the LDES feed
produced by their app instance.

## How to test
Read the added documentation and check whether is it correct and clear.