### PR TITLE
fix eli:date_publication using an incorrect predicate in statements

### DIFF
--- a/config/migrations/20260616063346-fix-eli-date-publication-statements.sparql
+++ b/config/migrations/20260616063346-fix-eli-date-publication-statements.sparql
@@ -1,0 +1,17 @@
+PREFIX eli: <http://data.europa.eu/eli/ontology#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+DELETE {
+  GRAPH ?g {
+    ?statement rdf:predicate eli:publication_date . 
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?statement rdf:predicate eli:date_publication . 
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?statement rdf:predicate eli:publication_date . 
+  } 
+}


### PR DESCRIPTION
This should be merged after https://github.com/semantic-ai/decide-geocoding-service/pull/48 is merged and released
See http://data.europa.eu/eli/ontology# to confirm the right predicate