### PR TITLE
fix(resource): relate works and expressions with cardinality 1

### DIFF
--- a/compose/validation.yml
+++ b/compose/validation.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - ../config/annotation-review:/config
   frontend-human-validator:
-    image: lblod/frontend-decide-human-validator:0.0.10
+    image: lblod/frontend-decide-human-validator:0.0.11
     labels:
       - 'logging=true'
     restart: always

--- a/config/resources/eli.lisp
+++ b/config/resources/eli.lisp
@@ -6,9 +6,12 @@
                 (:title :language-string ,(s-prefix "dct:title"))
                 (:date-document :date ,(s-prefix "eli:date_document"))
                 (:work-type :url ,(s-prefix "eli:work_type")))
-  :has-many `((expression :via ,(s-prefix "eli:is_realized_by")
-                          :as "is-realized-by")
-              (document :via ,(s-prefix "eli:related_to")
+  :has-one `(;; NOTE (18/06/2026): DECIDe' use cases each assume a 1-to-1 relation between works and
+             ;; expressions.  Therefore, we deviate from the ELI specification in which this
+             ;; relation has a 0..* cardinality.
+             (expression :via ,(s-prefix "eli:is_realized_by")
+                         :as "is-realized-by"))
+  :has-many `((document :via ,(s-prefix "eli:related_to")
                         :as "related-to")
               (organization :via ,(s-prefix "dct:creator")
                            :as "creator")


### PR DESCRIPTION
Each of DECIDe's use cases assume works and expressions have a 1-to-1
relation. While this deviates from ELI we do make this assumption explicit.

## How to test

0. Checkout this PR's branch and restart the `resources` service
1. Test the different frontends to see things still work as before.  For the HVT, see [#24](https://github.com/lblod/frontend-decide-human-validator/pull/24)

## Related PRs
- Update model in HVT: [#24](https://github.com/lblod/frontend-decide-human-validator/pull/24)

## Related tickets
- LBRON-1319