### PR TITLE
fix(authz): exclude mock-login from writing to harvesting graph

### DIFF
--- a/config/authorization/config.ttl
+++ b/config/authorization/config.ttl
@@ -86,12 +86,29 @@ ext:sessionService a odrl:PartyCollection ;
   vcard:fn "session service" ;
   dct:description "This party represent all session services running in the system." .
 
+# NOTE (19/06/2026): The filter excludes sessions associated with a mock-login
+# account.  This avoids that users using the yasgui/VC frontend can write to the
+# harvesting graph as their sessions are always linked to the mock-login
+# account.  This exclusion has two important drawbacks:
+# - If sessions for users authenticated via VC are in the future linked to
+#   non-mock-login accounts this filter will no longer work.
+# - If other types of authenticated users are added to the app, they will still
+#   be automatically members of this party and be granted the corresponding
+#   rights.
+#
+# If either of these two scenarios occur a better solution must be applied.
+# Since we do not expect them to occur within the scope of the DECIDe project
+# this solution is satisfactory.
 ext:authenticatedParty a odrl:PartyCollection ;
   vcard:fn "logged-in" ;
   ext:definedBy """PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+  PREFIX foaf: <http://xmlns.com/foaf/0.1/>
   SELECT DISTINCT ?account
   WHERE {
     <SESSION_ID> session:account ?account .
+    FILTER NOT EXISTS {
+      ?account foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service> .
+    }
   }""" ;
   dct:description "This represents all logged in users of the system." .
 

--- a/config/authorization/decide.lisp
+++ b/config/authorization/decide.lisp
@@ -235,10 +235,25 @@
     :to-graph ai
     :for-allowed-group "public"))
 
+;; NOTE (19/06/2026): The filter excludes sessions associated with a mock-login account.  This
+;; avoids that users using the yasgui/VC frontend can write to the harvesting graph as their
+;; sessions are always linked to the mock-login account.  This exclusion has two important
+;; drawbacks:
+;; - If sessions for users authenticated via VC are in the future linked to non-mock-login accounts
+;;   this filter will no longer work.
+;; - If other types of authenticated users are added to the app, they will still be automatically
+;;   members of this group and be granted the corresponding rights.
+;;
+;; If either of these two scenarios occur a better solution must be applied.  Since we do not expect
+;; them to occur within the scope of the DECIDe project this solution is satisfactory.
 (supply-allowed-group "logged-in"
                       :query "PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
       SELECT DISTINCT ?account WHERE {
-      <SESSION_ID> session:account ?account.
+        <SESSION_ID> session:account ?account.
+        FILTER NOT EXISTS {
+          ?account foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service> .
+        }
       }")
 
 (supply-allowed-group "organization-member"


### PR DESCRIPTION
All authenticated users received write access to the harvesting graph.  This includes users authenticated using VCs, which should only have read access.  This PR proposes to explicitly exclude such users from the authenticated user party to limit their access rights.


## Steps to reproduce

0. Launch your stack
1. Browse to http://yasgui.localhost/mock-login and log in as “Jane Doe”
2. In the input field write a query inserting triples for a resource type configured for the harvesting graph and execute the query. For example:

``` sparql
PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
INSERT DATA {
  ext:SomeBogusTask a task:Task .
}
```

3. Query the triplestore for the inserted data.  Either via yasqui or however you usually query triplestores during development.  For example, the following query gives the result shown in the table below the snippet.  (Note, when executing this query via yasgui the graph is stripped from the response, so there will be no value for ?g in the received results)

``` sparql
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
SELECT DISTINCT ?g ?p ?o
WHERE {
  GRAPH ?g {
    ext:SomeBogusTask ?p ?o .
  }
}
```

| g                                    | p                                               | o                                                  |
|--------------------------------------|-------------------------------------------------|----------------------------------------------------|
| http://mu.semte.ch/graphs/harvesting | http://www.w3.org/1999/02/22-rdf-syntax-ns#type | http://redpencil.data.gift/vocabularies/tasks/Task |


## Proposed solution
The query determining membership of the `ext:authenticatedParty` only checked whether an account is linked to the session, without checking further information for the account.  As a result all authenticated users automatically are members of this group.  Including users authenticated via VC/mock-login of the yasgui frontend, as their sessions are linked to the mock-login account.

The proposed solution here to add a filter to the `ext:authenticatedParty` query that explicitly excludes mock-login accounts.  This effectively excludes yasgui-frontend users from being members of this party and receiving its access rights.

This approach comes with two drawbacks:
- If sessions for users authenticated via VC are in the future linked to non-mock-login accounts this filter will no longer work.
- If other types of authenticated users are added to the app, they will still be automatically members of this party and be granted the corresponding rights.

If either of these two scenarios occur a better solution must be applied.  Since we do not expect them to occur within the scope of the DECIDe project this solution is satisfactory. (Despite it being against the security best practices of preferring allowlisting over disallowlisting.)


## How to test

0. Switch to this PR's branch and restart the `database` service to load the new config.
1. Repeat the steps in "Steps to reproduce".  In step 2 you should now receive an `Internal Server Error (#500)`.  The `database` logs should mention it did not write any triples and given an `UNWRITTEN-DATA-ERROR`:

``` shell
  database-1  | Requested:
  database-1  | SELECT ?index WHERE { VALUES ( ?index ?graph ?s ?p ?o ) { } GRAPH ?graph { ?s ?p ?o . } }
  database-1  | and received
  database-1  |
  database-1  | { "head": { "link": [], "vars": ["index"] },
  database-1  |   "results": { "distinct": false, "ordered": true, "bindings": [ ] } }
  database-1  | Requested:
  database-1  | SELECT ?index WHERE { VALUES ( ?index ?graph ?s ?p ?o ) { } GRAPH ?graph { ?s ?p ?o . } }
  database-1  | and received
  database-1  |
  database-1  | { "head": { "link": [], "vars": ["index"] },
  database-1  |   "results": { "distinct": false, "ordered": true, "bindings": [ ] } }
  database-1  | Warning, triples will not be written to triplestore:
  database-1  |  DELETE:
  database-1  |  INSERT:
  database-1  |   UNDEF <http://mu.semte.ch/vocabularies/ext/SomeBogusTask> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://redpencil.data.gift/vocabularies/tasks/Task>
  database-1  | Failed to process query, yielding 500.
  database-1  |
  database-1  | Error: #<UNWRITTEN-DATA-ERROR
  database-1  |   DELETE:
  database-1  |
  database-1  |   INSERT:
  database-1  |     (GRAPH NIL SUBJECT #S(MATCH :TERM IRIREF :RULE NIL :SUBMATCHES (#<SCANNED-TOKEN IRIREF[0,0]<http://mu.semte.ch/vocabularies/ext/SomeBogusTask>>)) PREDICATE #S(MATCH :TERM IRIREF :RULE NIL :SUBMATCHES (#<SCANNED-TOKEN IRIREF[0,0]<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>>)) OBJECT (#S(MATCH :TERM PNAME_LN :RULE NIL :SUBMATCHES (#<SCANNED-TOKEN PNAME_LN[149,158]NIL>)) . http://redpencil.data.gift/vocabularies/tasks/Task))
  database-1  |
  database-1  | >
  ```


Ensure the user still receives read rights.  For example, by performing the following query via yasgui.  Assuming your stack contains at least one `Task` resource this should return results.  (Since [#130](https://github.com/lblod/app-decide/pull/130) harvesting data is publicly readable.)

``` sparq
PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
SELECT ?s {
  ?s a task:Task .
} LIMIT 5
```

Ensure dashboard users can still create jobs:
1. Go to http://dashboard.localhost and log in.
2. Try to create a new job (any should do) and check whether it is actually created and the triples are written to the harvesting graph.


## Related tickets
- LBRON-1374 (problem statement + analysis)
- LBRON-1625 (implement solution)