### PR TITLE
have ai services use configured agent uri and custom start.sh script, explain about it in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@ This should be your go-to way of starting the stack.
 ./scripts/start.sh
 ```
 
-This script runs `docker compose up -d`, but first sets the APP_VERSION environment variable to the currently checked out tag or commit of this git repository. This is then passed into the AI services so that they track the provenance of the annotations that they create with an agent URI representing the versioned service with the configuration that corresponds to this tag or commit.
+This script runs `docker compose up -d`, but first sets the `APP_VERSION` environment variable to the currently checked out tag or commit of this git repository. This is then passed into the AI services so that they track the provenance of the annotations that they create with an agent URI representing the versioned service with the configuration that corresponds to this tag or commit.
+
+This environment variable is used in the AI services (see `./compose/ai.yml`). They have the following set of environment variables:
+
+- `FORCE_VERSIONED_AGENT_URI`: when set to true, the service will crash unless a valid value containing `/commit/` or `/tree/` is set for the following two environment variables. This is a safety in case you forget to start the app using `./scripts/start.sh` and use `docker-compose up` instead.
+- `CONFIGURED_AGENT_URI`: the URI to use for the service as an agent regarding the provenance of the annotations it makes. The annotations created by the AI services are linked automatically to this URI. For instance, for linking it is set to `http://lblod.data.gift/id/components/named-entity-linking/decide${APP_VERSION}` so that it remembers it's the linking service, but ALSO which configuration the linking service uses as it points to the current tag/commit hash of this repository.
+- `CONFIG_REPO_URL`: the url of this repository to use, set to `https://github.com/lblod/app-decide${APP_VERSION}` so it takes the current commit hash or tag into account. That way, the AI services can register their agent in the database pointing to the correct repository for its configuration.
 
 ### Account management for the pipeline dashboard
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,13 @@ COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml:docker-compose.override.y
 This should be your go-to way of starting the stack.
 
 ```bash
-docker compose up -d # run without -d flag when you don't want to run it in the background
+./scripts/start.sh
 ```
 
+This script runs `docker compose up -d`, but first sets the APP_VERSION environment variable to the currently checked out tag or commit of this git repository. This is then passed into the AI services so that they track the provenance of the annotations that they create with an agent URI representing the versioned service with the configuration that corresponds to this tag or commit.
+
 ### Account management for the pipeline dashboard
+
 Accounts for the pipeline dashboard can be added (and removed) using migrations that insert (or delete) the necessary data in the triplestore. The following sections assume [mu-cli](https://github.com/mu-semtech/mu-cli) is installed on your system and is available in your system's `PATH` as `mu`.
 
 It is possible that the app instance you use to generate the migrations is not the same app instance for an account should be added (or removed). Therefore, the following sections marks steps that should be performed on the app instance for which an account changed with **Target:**. Other steps can be executed on a local development system.
@@ -64,9 +67,10 @@ It is possible that the app instance you use to generate the migrations is not t
 1. Execute the `generate-account` script provided by the `registration` service: `mu script registration generate-account --name NAME --account USERNAME --password PASSWORD`. This creates a migration in `config/migrations/TIMESTAMP-create-user-USERNAME.sparql`
 2. Move the generated migration to the `config/migrations/local/` folder of the app instance(s) on which this account should be available.
 3. **Target**: On each target app instance, restart the `migrations` service to execute the generated migrations add inserting the account data: `docker compose restart migrations`
-4. **Target**:  Login into pipeline dashboard of the target app instance using the `USERNAME` and `PASSWORD` specified in step 1 to ensure it works.
+4. **Target**: Login into pipeline dashboard of the target app instance using the `USERNAME` and `PASSWORD` specified in step 1 to ensure it works.
 
 #### Disabling an account
+
 To disable an account its status can be changed to inactive via a migration.
 
 1. Generate a new migration file using the `new` script provided by the `migrations` service: `mu script migrations new sparql NAME`. This will create a blank file `config/migrations/TIMESTAMP-NAME.sparql`, where `TIMESTAMP` is the time you executed the script.
@@ -100,7 +104,6 @@ DELETE {
 4. **Target**: On the target app instance, restart the `migrations` service to execute the migration and disable the account: `docker compose restart migrations` (Check the service logs to make sure the migration executed correctly.)
 5. **Target**: Optionally, verify that the disable user can no longer login into the pipeline dashboard of the app instance.
 
-
 Note, the UUIDs for accounts can be found in the migration file used to initially insert them to an app instance. If this file is no longer available, you can query the triplestore to find the appropriate UUID. For example, the following should provide a list of all known account names along with their UUID:
 
 ```bash
@@ -114,7 +117,6 @@ WHERE {
      mu:uuid ?accountUuid .
 };"
 ```
-
 
 ### Running on mac silicon
 
@@ -152,6 +154,7 @@ To include (smart) search features, the stack needs to be started with the `sear
 However, to avoid issues of started services waiting for the database and/or elasticsearch, it is advisable to start the stack in a 'staggered' manner:
 
 To reset the elasticsearch index, first throw away the current `elasticsearch` directory:
+
 ```
 rm -rf data/elasticsearch
 ```

--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -9,7 +9,7 @@ services:
   # AI PIPELINES
   ##############################################################################
   entity-linking:
-    image: semanticai/entity-linking-backend:0.0.4
+    image: semanticai/entity-linking-backend:0.1.0
     environment:
       TARGET_GRAPH: 'http://mu.semte.ch/graphs/public'
       DEFAULT_GRAPH: 'http://mu.semte.ch/graphs/harvesting'
@@ -58,7 +58,7 @@ services:
     restart: always
     logging: *default-logging
   pdf-content:
-    image: semanticai/decide-pdf-content-extraction:0.0.13
+    image: semanticai/decide-pdf-content-extraction:0.1.0
     environment:
       APACHE_TIKA_URL: 'http://apache-tika:9998/tika'
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
@@ -127,7 +127,7 @@ services:
     labels:
       - logging=true
   named-entity-recognition:
-    image: semanticai/decide-geocoding-service:0.0.9
+    image: semanticai/decide-geocoding-service:0.1.0
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting
@@ -179,7 +179,7 @@ services:
       - ollama serve & pid=$$! && sleep 5 && ollama pull embeddinggemma && wait $$pid
 
   codelist-labeling:
-    image: semanticai/codelist-labeling-service:0.0.4
+    image: semanticai/codelist-labeling-service:0.1.0
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting

--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -23,6 +23,9 @@ services:
       LLM_PROVIDER: 'mistral'
       LLM_MAX_RETRIES: 3
       MISTRAL_MODEL: 'ministral-14b-2512'
+      FORCE_VERSIONED_AGENT_URI: true
+      CONFIGURED_AGENT_URI: http://lblod.data.gift/id/components/named-entity-linking/decide${APP_VERSION}
+      CONFIG_REPO_URL: https://github.com/lblod/app-decide${APP_VERSION}
     logging: *default-logging
     labels:
       - logging=true
@@ -74,6 +77,9 @@ services:
       AI_GRAPH: http://mu.semte.ch/graphs/public/pdf
       ALLOW_MU_AUTH_SUDO: true
       MOUNTED_SHARE_FOLDER: '/mnt/share'
+      FORCE_VERSIONED_AGENT_URI: true
+      CONFIGURED_AGENT_URI: http://lblod.data.gift/id/components/pdf-to-eli/decide${APP_VERSION}
+      CONFIG_REPO_URL: https://github.com/lblod/app-decide${APP_VERSION}
     volumes:
       - ./../data/files:/mnt/share
       - ./../config/pdf-content/config.json:/app/config.json:ro # Mount config as read-only
@@ -139,6 +145,9 @@ services:
       AI_GRAPH: http://mu.semte.ch/graphs/public/pdf
       ALLOW_MU_AUTH_SUDO: true
       CONFIG_PATH: /app/config.json
+      FORCE_VERSIONED_AGENT_URI: true
+      CONFIGURED_AGENT_URI: http://lblod.data.gift/id/components/named-entity-recognition/decide${APP_VERSION}
+      CONFIG_REPO_URL: https://github.com/lblod/app-decide${APP_VERSION}
     volumes:
       - ./../config/ner/config.json:/app/config.json:ro # Mount config as read-only
     depends_on:
@@ -188,6 +197,9 @@ services:
       AI_GRAPH: http://mu.semte.ch/graphs/public/pdf
       ALLOW_MU_AUTH_SUDO: true
       NOMINATIM_ENDPOINT: http://nominatim:8080/
+      FORCE_VERSIONED_AGENT_URI: true
+      CONFIGURED_AGENT_URI: http://lblod.data.gift/id/components/codelist-labeling/decide${APP_VERSION}
+      CONFIG_REPO_URL: https://github.com/lblod/app-decide${APP_VERSION}
     restart: always
     labels:
       - logging=true

--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -127,7 +127,7 @@ services:
     labels:
       - logging=true
   named-entity-recognition:
-    image: semanticai/decide-geocoding-service:0.1.0
+    image: semanticai/decide-geocoding-service:0.1.1
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting

--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -179,7 +179,7 @@ services:
       - ollama serve & pid=$$! && sleep 5 && ollama pull embeddinggemma && wait $$pid
 
   codelist-labeling:
-    image: semanticai/codelist-labeling-service:0.1.0
+    image: semanticai/codelist-labeling-service:0.1.1
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting

--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -58,7 +58,7 @@ services:
     restart: always
     logging: *default-logging
   pdf-content:
-    image: semanticai/decide-pdf-content-extraction:0.1.0
+    image: semanticai/decide-pdf-content-extraction:0.1.1
     environment:
       APACHE_TIKA_URL: 'http://apache-tika:9998/tika'
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Get the current Git tag, commit hash, or fall back to 'unversioned'
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    # Inside a Git repo
+    if APP_VERSION=$(git describe --tags --exact-match 2>/dev/null); then
+        # Use the exact tag if available
+        APP_VERSION="/tree/$APP_VERSION"
+    elif APP_VERSION=$(git rev-parse HEAD 2>/dev/null); then
+        # Fall back to commit hash if no tag
+        APP_VERSION="/commit/$APP_VERSION"
+    else
+        APP_VERSION="unversioned"
+    fi
+else
+    # Not in a Git repo
+    APP_VERSION="unversioned"
+fi
+
+# Export the result
+echo "starting Decide stack with APP_VERSION=$APP_VERSION"
+APP_VERSION=$APP_VERSION docker compose up -d


### PR DESCRIPTION
## description
have ai services use configured agent uri and custom start.sh script, explain about it in the readme

## how to test
Run the start.sh script as explained in the readme, keep the default env vars the same. 
Run a pipeline, notice that the annotations are now generated by a task that has prov:wasAssociatedWith the uri that represents the versioned service with its configuration.

