### PR TITLE
chore(frontend): bump frontend-decide-question-answering to version 0.0.4

### DIFF
--- a/compose/search.yml
+++ b/compose/search.yml
@@ -53,7 +53,7 @@ services:
   ### Smart search
   ##################################
   frontend-smart-search:
-    image: lblod/frontend-decide-question-answering:0.0.3
+    image: lblod/frontend-decide-question-answering:0.0.4
     labels:
       - 'logging=true'
     restart: always


### PR DESCRIPTION
v0.0.3 of the smart search front end is incompatible with v0.0.2 of the question answering service.
This is because the way the municipality is being passed through in the request.

