### PR TITLE
limiting scheduled jobs

### DIFF
--- a/compose/pipeline.yml
+++ b/compose/pipeline.yml
@@ -47,7 +47,7 @@ services:
     restart: always
     logging: *default-logging
   scheduled-job-controller:
-    image: lblod/scheduled-job-controller-service:feature-allow-copying-job-predicates-from-scheduled-job
+    image: lblod/scheduled-job-controller-service:1.3.0
     environment:
       LOG_SPARQL_ALL: 'false'
       DEBUG_AUTH_HEADERS: 'false'
@@ -60,7 +60,7 @@ services:
     restart: always
     logging: *default-logging
   annotation-job-splitter:
-    image: lblod/annotation-job-splitter-service:0.0.3
+    image: lblod/annotation-job-splitter-service:0.0.4
     restart: always
     logging: *default-logging
     volumes:

--- a/compose/pipeline.yml
+++ b/compose/pipeline.yml
@@ -47,7 +47,7 @@ services:
     restart: always
     logging: *default-logging
   scheduled-job-controller:
-    image: lblod/scheduled-job-controller-service:1.2.1
+    image: lblod/scheduled-job-controller-service:feature-allow-copying-job-predicates-from-scheduled-job
     environment:
       LOG_SPARQL_ALL: 'false'
       DEBUG_AUTH_HEADERS: 'false'
@@ -55,6 +55,8 @@ services:
       MU_APPLICATION_GRAPH: 'http://mu.semte.ch/graphs/harvesting'
     labels:
       - 'logging=true'
+    volumes:
+      - ../config/scheduled-job-controller:/config
     restart: always
     logging: *default-logging
   annotation-job-splitter:

--- a/config/annotation-job-splitter/config.ts
+++ b/config/annotation-job-splitter/config.ts
@@ -30,6 +30,16 @@ export default {
               'http://lblod.data.gift/id/jobs/concept/TaskOperation/annotation-split-tasks',
             nextOperation:
               'http://lblod.data.gift/id/jobs/concept/TaskOperation/translating',
+            resourceLimit: 1000,
+            resourceFilter: `
+              FILTER NOT EXISTS {
+                ?original <http://purl.org/linguistics/gold/translation> ?resource .
+              }
+              FILTER NOT EXISTS {
+                ?someTask <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/TaskOperation/eli-translation> .
+                ?someTask <http://redpencil.data.gift/vocabularies/tasks/inputContainer> / <http://redpencil.data.gift/vocabularies/tasks/hasResource> ?resource .
+              }
+            `,
           },
         ],
       },

--- a/config/scheduled-job-controller/config.js
+++ b/config/scheduled-job-controller/config.js
@@ -1,0 +1,8 @@
+export default {
+  jobPredicatesToCopy: [
+    'http://mu.semte.ch/vocabularies/ext/shapeForTargets',
+    'http://mu.semte.ch/vocabularies/ext/propertyPathForText',
+    'http://mu.semte.ch/vocabularies/ext/splitDecisions',
+    'http://mu.semte.ch/vocabularies/ext/graphForTargets',
+  ],
+};


### PR DESCRIPTION
## Description
fixes the scheduled job controller not copying important info from scheduled job to jobs

adds config so the splitter can limit the resources considered when the shape only contains a class, no resource uris.

Note that this builds on a feature branch of the scheduled-job-controller: https://github.com/lblod/scheduled-job-controller-service/pull/7

## How to test
- Use the linked annotation-job-splitter pr, build that version and put it in your override: https://github.com/lblod/annotation-job-splitter-service/pull/6
- edit the resource limit to 3 for convenience
- create a scheduled job to perform enrichment of eli decisions from gent, do not provide a set of uris to handle
- note that now the job that is created DOES contain the important info for the job-splitter
- see that only 3 tasks are created instead of 43k
- on the next run, see that these three decisions are no longer considered and 3 new ones are considered instead

settings for the scheduled job: 
<img width="872" height="1239" alt="image" src="https://github.com/user-attachments/assets/6c48f487-c5b6-4fd9-ae8d-0947282f1afe" />
