### PR TITLE
Fix rdf:body to rdf:object in config municipality linker

### DIFF
--- a/config/municipality-linker/config.ts
+++ b/config/municipality-linker/config.ts
@@ -6,7 +6,7 @@ export const municipalityLink = `
       ?annotation oa:hasTarget / oa:hasSource? ?decision .
       ?annotation oa:hasBody ?body .
       ?body rdf:predicate <http://data.europa.eu/eli/ontology#passed_by> .
-      ?body rdf:body ?target .
+      ?body rdf:object ?target .
     } UNION {
       ?task <http://redpencil.data.gift/vocabularies/tasks/inputContainer> / <http://redpencil.data.gift/vocabularies/tasks/hasResource> ?target .
       ?task <http://redpencil.data.gift/vocabularies/tasks/inputContainer> / <http://redpencil.data.gift/vocabularies/tasks/hasResource> ?decision .


### PR DESCRIPTION
The rdf:Statement of an oa:Annotation has rdf:subject, rdf:predicate and rdf:object as predicates.
For municipality linking, the subject is the decision, the predicate eli:passed_by, and object is the municipality.
rdf:body does not exists, so we fix this here