### PR TITLE
Add sampling to shacl report

### DIFF
--- a/compose/reporting.yml
+++ b/compose/reporting.yml
@@ -11,6 +11,8 @@ services:
       RUN_SPARQL_VALIDATIONS: false
       ONLY_KEEP_LATEST_REPORT: true
       RUN_REPORT_NOW: true
+      SAMPLING_ENABLED: true
+      SAMPLING_SIZE: 100
     volumes:
       - ../config/reports:/config
     restart: always

--- a/compose/reporting.yml
+++ b/compose/reporting.yml
@@ -5,7 +5,7 @@ x-logging: &default-logging
     max-file: '3'
 services:
   report-generation:
-    image: lblod/loket-report-generation-service:0.8.9
+    image: lblod/loket-report-generation-service:0.8.10
     environment:
       DEFAULT_GRAPH: 'http://mu.semte.ch/graphs/reports'
       RUN_SPARQL_VALIDATIONS: false

--- a/config/reports/README.md
+++ b/config/reports/README.md
@@ -44,6 +44,8 @@ The following enviroment variables can be configured:
 * `INSERT_BATCH_SIZE`: Number of triples that will be insert per batch. Defaults to `100`.
 * `ONLY_KEEP_LATEST_REPORT`: Boolean that allows, when set to `true`, to only keep the most recent version of a report during its creation and to delete oder versions. Defaults to `false`
 * `RUN_REPORT_NOW`: service automatically starts at start up
+* `SAMPLING_ENABLED`: Boolean that limits validation to a sample of resources per target class. Defaults to `true`.
+* `SAMPLING_SIZE`: Maximum number of resources to validate per target class when `SAMPLING_ENABLED` is `true`. Defaults to `100`.
 
 ## SPARQL-based validation
 

--- a/config/reports/shacl-report.js
+++ b/config/reports/shacl-report.js
@@ -62,6 +62,7 @@ const safeNamedGraphs = namedGraphs
   .join('\n');
 
 const cronFunction = async (namedGraph = null) => {
+    await waitForDatabase();
     console.log("report starts");
     try {
         // Read all SHACL files in the shacl folder
@@ -223,4 +224,25 @@ function addTimestamps(reportDataset, reportURI, createdTime) {
             ),
         ),
     );
+}
+
+async function waitForDatabase() {
+  const maxRetries = 30;
+  const delayMs = 2000;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await querySudo('ASK { ?s ?p ?o }');
+      console.log('Database connection established');
+      return;
+    } catch {
+      console.log(`Waiting for database... (attempt ${attempt}/${maxRetries})`);
+      if (attempt === maxRetries) {
+        throw new Error(
+          `Failed to connect to database after ${maxRetries} attempts`,
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
 }

--- a/config/reports/shacl-report.js
+++ b/config/reports/shacl-report.js
@@ -30,6 +30,16 @@ export const RUN_SPARQL_VALIDATIONS = env
   .get('RUN_SPARQL_VALIDATIONS')
   .default('false')
   .asBool();
+
+export const SAMPLING_ENABLED = env
+  .get('SAMPLING_ENABLED')
+  .default('true')
+  .asBool();
+
+export const SAMPLING_SIZE = env
+  .get('SAMPLING_SIZE')
+  .default('100')
+  .asIntPositive();
   
 import { sparqlEscapeUri, uuid } from "mu";
 import { querySudo } from '@lblod/mu-auth-sudo';
@@ -70,11 +80,12 @@ const cronFunction = async (namedGraph = null) => {
         const reportURI = `http://data.lblod.info/id/reports/${reportUUID}`;
         const created = new Date().toISOString();
         for (const targetClass of allTargetClasses) {
-            const count = await countResources(targetClass, namedGraphs);
-            console.log(`Adding ${count} resources for graphs ${safeNamedGraphs} and resource type ${targetClass}...`);
+            const totalCount = await countResources(targetClass, namedGraphs);
+            const count = SAMPLING_ENABLED ? Math.min(totalCount, SAMPLING_SIZE) : totalCount;
+            console.log(`Adding ${count} resources for graphs ${safeNamedGraphs} and resource type ${targetClass}${SAMPLING_ENABLED ? ` (sampling enabled, total: ${totalCount})` : ''}...`);
             for (let offset = 0; offset < count; offset += BATCH_SIZE) {
                 const dataDataset = new Store();
-                await fillDataDataset(targetClass, offset, dataDataset, shapesDataset, sparqlShapeDataset);
+                await fillDataDataset(targetClass, offset, count, dataDataset);
                 const batchReportDataset = await validateShapesAndSparql(dataDataset, shapesDataset, sparqlValidationObjects, reportURI, reportUUID);
                 addTimestamps(batchReportDataset, reportURI, created);
                 await saveDatasetToNamedGraphs(batchReportDataset, namedGraphs);
@@ -101,7 +112,7 @@ export default {
 };
 
 // Fill dataDataset, one level deep (?resource ?p ?o), with resources of type target class
-async function fillDataDataset(targetClass, offset, dataDataset) {
+async function fillDataDataset(targetClass, offset, count, dataDataset) {
     const resources = [];
     const resourcesResult = await querySudo(`
     SELECT DISTINCT ?resource
@@ -114,7 +125,7 @@ async function fillDataDataset(targetClass, offset, dataDataset) {
                 ?resource a ${sparqlEscapeUri(targetClass)} .
             }
         }
-    LIMIT ${BATCH_SIZE}
+    LIMIT ${Math.min(BATCH_SIZE, count - offset)}
     OFFSET ${offset}
     `);
     resourcesResult.results.bindings.forEach((binding) => {

--- a/docs/docker-compose.override.bamberg.yml
+++ b/docs/docker-compose.override.bamberg.yml
@@ -108,12 +108,13 @@ services:
   # vc-issuer:
   #   entrypoint: ["echo", "Service vc-issuer is disabled"]
 
+  # Uncomment to disable data quality manager service
+  # This service allows to generate reports about data quality, meant for
+  # internal monitoring
+  # report-generation:
+  #   entrypoint: ["echo", "Service report-generation is disabled"]
 
-  # Comment to enable general services
-  report-generation:
-    # This service allows to generate reports about data quality, meant for
-    # internal monitoring
-    entrypoint: ["echo", "Service report-generation is disabled"]
+  # Comment to enable general services    
   acmidm-login:
     # This service is used to integrate with ACMIDM, a Belgian single sign-on
     # solution based on Oauth2 and OpenID

--- a/docs/docker-compose.override.freiburg.yml
+++ b/docs/docker-compose.override.freiburg.yml
@@ -107,12 +107,13 @@ services:
   # vc-issuer:
   #   entrypoint: ["echo", "Service vc-issuer is disabled"]
 
+  # Uncomment to disable data quality manager service
+  # This service allows to generate reports about data quality, meant for
+  # internal monitoring
+  # report-generation:
+  #   entrypoint: ["echo", "Service report-generation is disabled"]
 
   # Comment to enable general services
-  report-generation:
-    # This service allows to generate reports about data quality, meant for
-    # internal monitoring
-    entrypoint: ["echo", "Service report-generation is disabled"]
   acmidm-login:
     # This service is used to integrate with ACMIDM, a Belgian single sign-on
     # solution based on Oauth2 and OpenID

--- a/docs/docker-compose.override.ghent.yml
+++ b/docs/docker-compose.override.ghent.yml
@@ -93,12 +93,13 @@ services:
   # vc-issuer:
   #   entrypoint: ["echo", "Service vc-issuer is disabled"]
 
+  # Uncomment to disable data quality manager service
+  # This service allows to generate reports about data quality, meant for
+  # internal monitoring
+  # report-generation:
+  #   entrypoint: ["echo", "Service report-generation is disabled"]
 
   # Comment to enable general services
-  report-generation:
-    # This service allows to generate reports about data quality, meant for
-    # internal monitoring
-    entrypoint: ["echo", "Service report-generation is disabled"]
   acmidm-login:
     # This service is used to integrate with ACMIDM, a Belgian single sign-on
     # solution based on Oauth2 and OpenID


### PR DESCRIPTION
# context

This PR limits the number of resources (decisions) that the report service will validate.
Batching is added for performance when deleting report and results (v0.8.10 report generation service)
Docker compose of the cities is updated to enable the report generation service (aka data quality manager) by default.
Also, adds a waitForDatabase on startup

# how to test
- Run the app with a [partner configation](https://github.com/lblod/app-decide/tree/development/docs#partner-configurations): for example, in your .env file: `COMPOSE_FILE=docker-compose.yml:./docs/docker-compose.override.bamberg.yml:docker-compose.override.yml:docker-compose.mac.yml`
- In your docker-compose.override.yml, open the port of the identifier service, so we can contact the report-generation API for checking later: 
```
  identifier:
    ports:
      - "80:80"
```
- This should spin up the report-generation service in sampling mode:
<img width="968" height="624" alt="image" src="https://github.com/user-attachments/assets/7156faed-d5e2-4b68-9487-452653cc755e" />
- In the logs, you should see `Done validating` after a while:
<img width="968" height="624" alt="image" src="https://github.com/user-attachments/assets/2179312a-5a1a-4780-944a-62cbca94e6e4" />
- Check `http://localhost/shacl-reports/shacl-reports/latest/issues`, you should see 800-ish results: 
<img width="968" height="624" alt="image" src="https://github.com/user-attachments/assets/5668f3fb-8f0c-43ad-ae80-0180e6884538" />



