### PR TITLE
add checked for scheduling predicate on tasks so the frontend can set it to null when restarting a task

### DIFF
--- a/config/resources/job.json
+++ b/config/resources/job.json
@@ -142,6 +142,10 @@
                     "type": "datetime",
                     "predicate": "dct:modified"
                 },
+                "checked-for-scheduling": {
+                    "type": "datetime",
+                    "predicate": "ext:checkedForScheduling"
+                },
                 "status": {
                     "type": "url",
                     "predicate": "adms:status"


### PR DESCRIPTION
## description
with the new change in the job-controller to mark tasks in final states that it already checked, restarting such tasks requires clearing this predicate. We need to make resources aware of this predicate so the frontend can clear it and the job-controller can re-evaluate the task status.

## how to test
- use the frontend version from this pr: https://github.com/lblod/frontend-harvesting-self-service/pull/69
- pick a task that has already completed that is in the middle of a pipeline, preferably a failed one in a small pipeline so you can easily track what happens
- restart the task
- when the task completes, the job controller should start the follow up task