### PR TITLE
fix: resolve pdf-content per-PDF segmentation connection error (sync release + nested llm config)

### DIFF
--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -58,7 +58,7 @@ services:
     restart: always
     logging: *default-logging
   pdf-content:
-    image: semanticai/decide-pdf-content-extraction:0.1.1
+    image: semanticai/decide-pdf-content-extraction:0.1.2
     environment:
       APACHE_TIKA_URL: 'http://apache-tika:9998/tika'
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting

--- a/config/pdf-content/config.json
+++ b/config/pdf-content/config.json
@@ -11,11 +11,13 @@
     "enable_refinement": true
   },
   "segmentation": {
-    "model_name": "mistral-medium-3.5",
-    "endpoint": "https://api.mistral.ai/v1",
+    "llm": {
+      "provider": "mistralai",
+      "model_name": "mistral-medium-3.5",
+      "base_url": "https://api.mistral.ai/v1",
+      "temperature": 0.1
+    },
     "max_new_tokens": 250000,
-    "text_limit_chars": 1000000,
-    "temperature": 0.1,
-    "max_gap": 5
+    "text_limit_chars": 1000000
   }
 }

--- a/docs/docker-compose.override.bamberg.yml
+++ b/docs/docker-compose.override.bamberg.yml
@@ -35,7 +35,7 @@ services:
     # This service is mostly configured in `../config/pdf-content/config.json`,
     # only secrets are configured via an environment variable.
     environment:
-      SEGMENTATION__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
+      SEGMENTATION__LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
   ## Disable services to harvest data from OParl endpoints
   ## Alternatively, comment the oparl.yml line in `pipeline.yml`
   oparl-to-eli:


### PR DESCRIPTION
## Summary

Rolls out the pdf-content `0.1.2` version and updates its config to match. This version moves
segmentation to a synchronous LangChain client, which fixes the recurring per-PDF
`Connection error` retries (~15s wasted per document). It also requires a nested
`segmentation.llm` config block and a renamed API-key env var.

## Changes

- `compose/ai.yml`: pdf-content `0.1.1` → `0.1.2`
- `config/pdf-content/config.json`: segmentation settings moved under `segmentation.llm`
  (`provider`/`model_name`/`base_url`/`temperature`); stale `max_gap` dropped
- `docs/docker-compose.override.bamberg.yml`: `SEGMENTATION__API_KEY` → `SEGMENTATION__LLM__API_KEY`

## Deployment note

The API key is now read from **`SEGMENTATION__LLM__API_KEY`** (was `SEGMENTATION__API_KEY`),
set in the local (untracked) override.