### PR TITLE
feat: add json-to-eli service

### DIFF
--- a/compose/json.yml
+++ b/compose/json.yml
@@ -1,0 +1,15 @@
+x-logging: &default-logging
+  driver: 'json-file'
+  options:
+    max-size: '10m'
+    max-file: '3'
+services:
+  json-to-eli:
+    # TODO: Uncomment when image is available
+    #image: lblod/decide-json-to-eli-service:0.0.1
+    environment:
+      DEFAULT_MU_AUTH_SCOPE: http://services.semantic.works/decide-json-to-eli-service
+    labels:
+      - 'logging=true'
+    restart: always
+    logging: *default-logging

--- a/compose/json.yml
+++ b/compose/json.yml
@@ -5,8 +5,7 @@ x-logging: &default-logging
     max-file: '3'
 services:
   json-to-eli:
-    # TODO: Uncomment when image is available
-    #image: lblod/decide-json-to-eli-service:0.0.1
+    image: lblod/decide-json-to-eli-service:0.0.1
     environment:
       DEFAULT_MU_AUTH_SCOPE: http://services.semantic.works/decide-json-to-eli-service
     labels:

--- a/compose/pipeline.yml
+++ b/compose/pipeline.yml
@@ -6,6 +6,7 @@ x-logging: &default-logging
 include:
   - oparl.yml
   - oslo.yml
+  - json.yml
   - ai.yml
 services:
   ##############################################################################

--- a/config/annotation-job-splitter/config.ts
+++ b/config/annotation-job-splitter/config.ts
@@ -43,5 +43,16 @@ export default {
           },
         ],
       },
+    'http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/json-to-eli':
+      {
+        taskConfiguration: [
+          {
+            currentOperation:
+              'http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-json-to-eli',
+            nextOperation:
+              'http://lblod.data.gift/id/jobs/concept/TaskOperation/translating',
+          },
+        ],
+      },
   },
 };

--- a/config/annotation-job-splitter/config.ts
+++ b/config/annotation-job-splitter/config.ts
@@ -43,7 +43,7 @@ export default {
           },
         ],
       },
-    'http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/json-to-eli':
+    'http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/json-to-enriched':
       {
         taskConfiguration: [
           {

--- a/config/authorization/config.ttl
+++ b/config/authorization/config.ttl
@@ -71,7 +71,8 @@ ext:decideAuthorizationPolicy a odrl:Set ;
     ext:allowWriteForSession ,
     ext:allowReadPublicForSession ,
     ext:allowReadOrgsForSession ,
-    ext:allowPublicReadForAuthz .
+    ext:allowPublicReadForAuthz ,
+    ext:allowWritePdfForJsonToEli .
 
 # Parties for groups
 ext:decideSystem a odrl:Party ;
@@ -373,6 +374,12 @@ ext:allowReadAiSliceForQuestionAnswering a odrl:Permission ;
   odrl:assigner ext:decideSystem ;
   odrl:assignee ext:publicParty ;
   ext:scope "http://services.semantic.works/decide-question-answering-service" .
+
+ext:allowWritePdfForJsonToEli a odrl:Permission ;
+  odrl:action odrl:modify ;
+  odrl:target ext:decideHarvestedPdfSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/decide-json-to-eli-service" .
 
 
 # Assets (SHACL shapes) for type specifications

--- a/config/authorization/config.ttl
+++ b/config/authorization/config.ttl
@@ -72,7 +72,9 @@ ext:decideAuthorizationPolicy a odrl:Set ;
     ext:allowReadPublicForSession ,
     ext:allowReadOrgsForSession ,
     ext:allowPublicReadForAuthz ,
-    ext:allowWritePdfForJsonToEli .
+    ext:allowWritePdfForJsonToEli ,
+    ext:allowReadForHarvestingJsonToEli ,
+    ext:allowWriteForHarvestingJsonToEli .
 
 # Parties for groups
 ext:decideSystem a odrl:Party ;
@@ -381,6 +383,19 @@ ext:allowWritePdfForJsonToEli a odrl:Permission ;
   odrl:assignee ext:publicParty ;
   ext:scope "http://services.semantic.works/decide-json-to-eli-service" .
 
+ext:allowReadForHarvestingJsonToEli a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestingSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/decide-json-to-eli-service" .
+
+ext:allowWriteForHarvestingJsonToEli a odrl:Permission ;
+  odrl:action odrl:modify ;
+  odrl:target ext:decideHarvestingSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/decide-json-to-eli-service" .
 
 # Assets (SHACL shapes) for type specifications
 ext:BesluitAdministrativeUnitAsset a odrl:Asset, sh:NodeShape ;

--- a/config/delta/json-to-eli.js
+++ b/config/delta/json-to-eli.js
@@ -1,0 +1,24 @@
+export default [
+  {
+    match: {
+      predicate: {
+        type: 'uri',
+        value: 'http://www.w3.org/ns/adms#status',
+      },
+      object: {
+        type: 'uri',
+        value: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+      },
+    },
+    callback: {
+      method: 'POST',
+      url: 'http://json-to-eli/delta',
+    },
+    options: {
+      resourceFormat: 'v0.0.1',
+      gracePeriod: 1000,
+      ignoreFromSelf: true,
+      sendMatchesOnly: true,
+    },
+  },
+];

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -7,6 +7,7 @@ import resource from './resource';
 import codelist from './codelist';
 import annotationJobSplitter from './annotation-job-splitter';
 import ldes from './ldes';
+import jsonToEli from './json-to-eli';
 
 export default [
   ...resource,
@@ -14,6 +15,7 @@ export default [
   ...jobController,
   ...pdfToEli,
   ...osloToEli,
+  ...jsonToEli,
   ...search,
   ...codelist,
   ...annotationJobSplitter,

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -182,6 +182,13 @@ defmodule Dispatcher do
   end
 
   #################
+  # JSON-TO-ELI
+  #################
+  match "/json-to-eli/*path", %{ accept: [:any], layer: :api_services } do
+    Proxy.forward conn, path, "http://json-to-eli/"
+  end
+
+  #################
   # RESOURCES
   #################
 

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -67,6 +67,40 @@
       }
     ]
   },
+  "http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/json-to-eli": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextIndex": "0"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/json-to-eli",
+        "nextIndex": "1"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/json-to-eli",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/translating",
+        "nextIndex": "2"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/translating",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/segmenting",
+        "nextIndex": "3"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/segmenting",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
+        "nextIndex": "4"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/named-entity-linking",
+        "nextIndex": "5"
+      }
+    ]
+  },
   "http://lblod.data.gift/id/jobs/concept/JobOperation/ner-and-nel-annotations": {
     "tasksConfiguration": [
       {

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -44,6 +44,25 @@
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-to-eli",
         "nextIndex": "2"
+      }
+    ]
+  },
+  "http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/pdf-to-enriched": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextIndex": "0"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping",
+        "nextIndex": "1"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-to-eli",
+        "nextIndex": "2"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-to-eli",
@@ -68,6 +87,20 @@
     ]
   },
   "http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/json-to-eli": {
+    "tasksConfiguration": [
+      {
+        "currentOperation": null,
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextIndex": "0"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/json-to-eli",
+        "nextIndex": "1"
+      }
+    ]
+  },
+  "http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/json-to-enriched": {
     "tasksConfiguration": [
       {
         "currentOperation": null,

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -81,23 +81,29 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/json-to-eli",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/translating",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-json-to-eli",
         "nextIndex": "2"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-json-to-eli",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/translating",
+        "nextIndex": "3",
+        "external": true
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/translating",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/segmenting",
-        "nextIndex": "3"
+        "nextIndex": "4"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/segmenting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
-        "nextIndex": "4"
+        "nextIndex": "5"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/named-entity-linking",
-        "nextIndex": "5"
+        "nextIndex": "6"
       }
     ]
   },

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -127,3 +127,5 @@ services:
     links:
       - database:database
     restart: no
+  json-to-eli:
+    restart: no


### PR DESCRIPTION
This adds the new json-to-eli service to the app.  This service will fetch JSON data and convert it to ELI expressions.  This is used as an alternative input method for Bamberg.

This PR also adds a new json-to-eli pipeline, similar, to the existing pdf-to-eli pipeline.  In this pipeline the new service first add the necessary ELI Expressions and Works based on the JSON data it fetches.  Afterwards, the job-splitter splits the job into multiple parallel tasks, one task per expression that was added.  The remainder of the pipeline is the same as the pdf-to-eli pipeline, starting from the `translating` task.


## How to test
0. Check out this branch.
1. Restart the services whose configurations have been updated:

``` shell
docker compose restart annotation-job-splitter database deltanotifier dispatcher job-controller
```

2. Follow the further instructions in service PR [#1](https://github.com/lblod/decide-json-to-eli-service/pull/1).


## TODO
- [x] Uncomment service's tagged version image in drc config once available.


## Related PRs
- Service [#1](https://github.com/lblod/decide-json-to-eli-service/pull/1)


## Related tickets
- LBRON-1651