### PR TITLE
publish the ODRL parts of dcat descriptions on ldes, also publish the mu-auth config on ldes

### DIFF
--- a/config/ldes-delta-pusher/config.ts
+++ b/config/ldes-delta-pusher/config.ts
@@ -1,10 +1,13 @@
 import { sparqlEscapeUri } from 'mu';
 
 export const PUBLIC_GRAPH = 'http://mu.semte.ch/graphs/public';
+export const MU_AUTH_CONFIG_GRAPH =
+  'http://mu.semte.ch/graphs/odrl-authorization-policy';
 
 export const PUBLIC_GRAPH_FILTER = `
   VALUES ?g {
     ${sparqlEscapeUri(PUBLIC_GRAPH)}
+    ${sparqlEscapeUri(MU_AUTH_CONFIG_GRAPH)}
 }`;
 
 // NOTE (28/05/2026): Not all interesting resources have a triple for this
@@ -46,6 +49,46 @@ export const streams: LdesConfig = {
       healingPredicates: [HEALING_PREDICATE],
     },
     'http://www.w3.org/ns/dcat#CatalogRecord': {
+      graphFilter: PUBLIC_GRAPH_FILTER,
+      healingPredicates: [HEALING_PREDICATE],
+    },
+    'http://www.w3.org/ns/odrl/2/Offer': {
+      graphFilter: PUBLIC_GRAPH_FILTER,
+      healingPredicates: [HEALING_PREDICATE],
+    },
+    'https://schema.org/Offer': {
+      graphFilter: PUBLIC_GRAPH_FILTER,
+      healingPredicates: [HEALING_PREDICATE],
+    },
+    'https://schema.org/HowTo': {
+      graphFilter: PUBLIC_GRAPH_FILTER,
+      healingPredicates: [HEALING_PREDICATE],
+    },
+    'http://www.w3.org/ns/odrl/2/Set': {
+      graphFilter: PUBLIC_GRAPH_FILTER,
+      healingPredicates: [HEALING_PREDICATE],
+    },
+    'http://www.w3.org/ns/odrl/2/Permission': {
+      graphFilter: PUBLIC_GRAPH_FILTER,
+      healingPredicates: [HEALING_PREDICATE],
+    },
+    'http://www.w3.org/ns/odrl/2/Prohibition': {
+      graphFilter: PUBLIC_GRAPH_FILTER,
+      healingPredicates: [HEALING_PREDICATE],
+    },
+    'http://www.w3.org/ns/odrl/2/Party': {
+      graphFilter: PUBLIC_GRAPH_FILTER,
+      healingPredicates: [HEALING_PREDICATE],
+    },
+    'http://www.w3.org/ns/odrl/2/PartyCollection': {
+      graphFilter: PUBLIC_GRAPH_FILTER,
+      healingPredicates: [HEALING_PREDICATE],
+    },
+    'http://www.w3.org/ns/odrl/2/AssetCollection': {
+      graphFilter: PUBLIC_GRAPH_FILTER,
+      healingPredicates: [HEALING_PREDICATE],
+    },
+    'http://www.w3.org/ns/odrl/2/Asset': {
       graphFilter: PUBLIC_GRAPH_FILTER,
       healingPredicates: [HEALING_PREDICATE],
     },

--- a/config/migrations/20260703125728-make-dcat-odrl-ldes-ready.sparql
+++ b/config/migrations/20260703125728-make-dcat-odrl-ldes-ready.sparql
@@ -1,0 +1,97 @@
+PREFIX odrl: <http://www.w3.org/ns/odrl/2/> 
+PREFIX dcat: <http://www.w3.org/ns/dcat#>  
+PREFIX dct: <http://purl.org/dc/terms/>  
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> 
+PREFIX foaf: <http://xmlns.com/foaf/0.1/> 
+PREFIX schema: <https://schema.org/> 
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX private-ds-ex: <http://decide.data.gift/datasets/example/60e19fdf-b549-41b9-9adf-420379285127/> 
+PREFIX public-ds-ex: <http://decide.data.gift/datasets/example/1ae2da8e-9889-426b-a7e8-9360c15ba2cd/> 
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/> 
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s dct:modified ?now.
+  }
+}
+WHERE {
+  VALUES ?s {
+    public-ds-ex:dataset
+    public-ds-ex:distribution
+    public-ds-ex:policy
+    private-ds-ex:dataset
+    private-ds-ex:distribution    
+    private-ds-ex:policy
+    private-ds-ex:licensedUserCollection
+    private-ds-ex:licenseOffering
+    private-ds-ex:howTo
+  }
+  ?s a ?thing .
+  FILTER NOT EXISTS {
+    ?s dct:modified ?modified.
+  }
+  BIND(NOW() AS ?now)
+};
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?ruleType ?rule.
+    ?rule ?p ?o.
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?newRule dct:modified ?now.
+    ?s ?ruleType ?newRule.
+    ?newRule ?p ?o.
+    ?newRule a ?class .
+  }
+}
+WHERE {
+  VALUES ?s {
+    public-ds-ex:dataset
+    public-ds-ex:distribution
+    public-ds-ex:policy
+    private-ds-ex:dataset
+    private-ds-ex:distribution    
+    private-ds-ex:policy
+    private-ds-ex:licensedUserCollection
+    private-ds-ex:licenseOffering
+    private-ds-ex:howTo
+  }
+  VALUES (?ruleType ?class) {
+    (odrl:permission odrl:Permission)
+    (odrl:prohibition odrl:Prohibition)
+  }
+  ?s ?ruleType ?rule.
+  ?rule ?p ?o.
+
+  BIND(IRI(CONCAT(STR(?s), "/", SUBSTR(STR(?ruleType), 29))) AS ?newRule)
+  BIND(NOW() AS ?now)
+} ;
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?newRule mu:uuid ?id.
+  }
+}
+WHERE {
+  VALUES ?s {
+    public-ds-ex:dataset
+    public-ds-ex:distribution
+    public-ds-ex:policy
+    private-ds-ex:dataset
+    private-ds-ex:distribution    
+    private-ds-ex:policy
+    private-ds-ex:licensedUserCollection
+    private-ds-ex:licenseOffering
+    private-ds-ex:howTo
+  }
+  VALUES ?ruleType {
+    odrl:permission
+    odrl:prohibition
+  }
+  ?s ?ruleType ?newRule.
+
+BIND(STRUUID() AS ?id)
+}


### PR DESCRIPTION
## Description
This publishes the ODRL parts of dcat descriptions and the mu-auth config on the ldes feed. 

The ODRL policies connected to the DCAT datasets are essential if users want to know what is allowed/required regarding the datasets they find in the federating catalog.

Publishing the mu-auth config is more a nice-to-have thing, for people who want even more details on what they can or can't do with the sparql endpoints published by the decide stack.

## How to test

You can test this by making use of the dcat federation setup: https://github.com/lblod/app-decide-federating-catalog.

- clone the federating dcat app
- on the dev server, checkout this branch and republish the dcat feed
- locally, in the federating dcat app, use this config for the ldes-client:
```js
const config = {
  endpoints: [
    {
      name: 'public',
      LDES_BASE: 'https://ds.decide-dev.s.redhost.be/ldes/public/',
      FIRST_PAGE: 'https://ds.decide-dev.s.redhost.be/ldes/public/1',
      STATUS_GRAPH: 'http://mu.semte.ch/graphs/ldes/decide-public-status',
      TARGET_GRAPH: 'http://mu.semte.ch/graphs/ldes/decide-public',
      BATCH_GRAPH: 'http://mu.semte.ch/graphs/ldes/decide-public-batch',
    },
    {
      name: 'public-test',
      LDES_BASE: 'https://ds.decide.lblod.info/ldes/public/',
      FIRST_PAGE: 'https://ds.decide.lblod.info/ldes/public/1',
      STATUS_GRAPH: 'http://mu.semte.ch/graphs/ldes/decide-public-test-status',
      TARGET_GRAPH: 'http://mu.semte.ch/graphs/ldes/decide-public-test',
      BATCH_GRAPH: 'http://mu.semte.ch/graphs/ldes/decide-public-test-batch',
    },
  ],
};

export default config;
```
This will harvest both the dev and test ldes streams
- wait until the federation is done, you can tell by the new ttl files appearing in your federated ldes-feed/public directory
- then run the following queries to verify that the content made it to your federating catalog:
```sparql
  PREFIX odrl: <http://www.w3.org/ns/odrl/2/>
  SELECT * WHERE {
    graph ?g {
      ?s a odrl:Permission.
    }
  } order by ?s
```
This should only show items in your decide-public graph as test doesn't publish odrl policies yet
```sparql
  PREFIX dcat: <http://www.w3.org/ns/dcat#>
  SELECT * WHERE {
    graph ?g {
      ?s a dcat:Dataset.
    }
  } order by ?s
```
This should show the datasets in both target graphs
- verify the contents of the stream on dev, it should show all odrl types/properties attached to the dcat instances and all items in the mu-auth config
- verify the dcat interface, it shouldn't show any duplicates as the data from dev and test is the same