### PR TITLE
ignore normatieve bepaling in hvt

### DIFF
--- a/config/annotation-review/config.ts
+++ b/config/annotation-review/config.ts
@@ -30,7 +30,7 @@ export default {
           <http://lblod.data.gift/id/components/named-entity-linking/v1.0.0>
           <http://lblod.data.gift/id/components/pdf-to-eli/v1.0.0>
         }
-        FILTER(?type NOT IN (<http://www.w3.org/ns/locn#Address>, <https://data.vlaanderen.be/ns/adres#Straatnaam>, <http://www.wikidata.org/entity/Q2785216>, <http://www.wikidata.org/entity/Q123705> ))
+        FILTER(?type NOT IN (<http://www.w3.org/ns/locn#Address>, <https://data.vlaanderen.be/ns/adres#Straatnaam>, <http://www.wikidata.org/entity/Q2785216>, <http://www.wikidata.org/entity/Q123705>, <https://data.vlaanderen.be/ns/omgevingsvergunning#NormatieveBepaling> ))
         FILTER(!BOUND(?typeClass) || ?typeClass NOT IN ( <http://mu.semte.ch/vocabularies/ext/AnnotationBody> ))
         
       `,


### PR DESCRIPTION
This filters out the normatieve bepaling entities in HVT:

before: 
<img width="1680" height="819" alt="image" src="https://github.com/user-attachments/assets/4410430e-757b-4461-8f47-b2208f590daa" />

after: 
<img width="1680" height="819" alt="image" src="https://github.com/user-attachments/assets/6695061a-781c-465a-a977-8ea0fb40bfeb" />
