### PR TITLE
disabled almost all services for freiburg so they only keep the dcat and datadumps services

### DIFF
--- a/docs/docker-compose.override.freiburg.yml
+++ b/docs/docker-compose.override.freiburg.yml
@@ -25,6 +25,16 @@ services:
     entrypoint: ["echo", "Service file is disabled"]
 
   # Disable general data space services
+  frontend-yasgui:
+    restart: no
+    entrypoint: ["echo", "Service frontend-yasgui is disabled"]
+  registration:
+    restart: no
+    entrypoint: ["echo", "Service registration is disabled"]
+  dsp-auth-wrapper:
+    restart: no
+    entrypoint: ["echo", "Service dsp-auth-wrapper is disabled"]
+
   vc-issuer:
     restart: no
     entrypoint: ["echo", "Service vc-issuer is disabled"]

--- a/docs/docker-compose.override.freiburg.yml
+++ b/docs/docker-compose.override.freiburg.yml
@@ -1,4 +1,8 @@
 services:
+  # Freiburg goes for a minimal setup for now and simply wants to publish the DCAT
+  # data and distribution downloads created in the DECIDe project. The pipelines
+  # are run on central servers.
+  #
   # Example configuration when using app-letsencrypt as reverse proxy to forward
   # traffic to the app's identifier.
   # identifier:
@@ -15,122 +19,131 @@ services:
   #     - default
   #     - proxy
 
-  # Disable unneeded services for UC0.0 Dataspace
-  # This disables services that are used to collect decisions from other sources
-  # than PDFs
-  frontend-harvesting:
-    environment:
-      # Disable functionality to create jobs to harvest PDFs
-      EMBER_PDF_HARVESTING_ENABLED: false
-      # Disable functionality to create jobs to harvest data from OSLO endpoints
-      EMBER_OSLO_HARVESTING_ENABLED: false
-  ## Disable services to harvest data from OSLO endpoints (used by local
-  ## governments in Flanders)
-  ## Alternatively, comment the oslo.yml line in `pipeline.yml`
-  lokaal-beslist-consumer:
-    entrypoint: ["echo", "Service lokaal-beslist-consumer is disabled"]
-  decisions-ghent-filter:
-    entrypoint: ["echo", "Service decisions-ghent-filter is disabled"]
-  oslo-eli-transformer:
-    entrypoint: ["echo", "Service oslo-eli-transformer is disabled"]
-  ## Disable services to harvest data from PDFs
-  pdf-scraper:
-    entrypoint: ["echo", "Service pdf-scraper is disabled"]
-  pdf-content:
-    entrypoint: ["echo", "Service pdf-content is disabled"]
-  apache-tika:
-    entrypoint: ["echo", "Service apache-tika is disabled"]
+  # Disable unneeded base services:
+  file:
+    restart: no
+    entrypoint: ["echo", "Service file is disabled"]
 
-  # Disable services for UC0.1 Policy impact report
-  policy-impact-report:
-    entrypoint: ["echo", "Service policy-impact-report is disabled"]
-  frontend-policy-impact-report:
-    entrypoint: ["echo", "Service frontend-policy-impact-report is disabled"]
-
-  # Configure services for UC1 Restrictive Mobility Zones
-  # NOTE: It is advised to set API keys (and other secrets) in a non-versioned
-  # `docker-compose.override.yml` to avoid accidentally leaking such secrets.
-  named-entity-recognition:
-    # This service is mostly configured in `../config/ner/config.json`, only
-    # secrets are configured as environment variables.
-   environment:
-     # etranslation
-     TRANSLATION__ETRANSLATION__BEARER_TOKEN: "<REPLACE-WITH-TOKEN-IN-OVERRIDE-FILE>"
-     TRANSLATION__ETRANSLATION__PASSWORD: "<REPLACE-WITH-PASSWORD-IN-OVERRIDE-FILE>"
-     # segmentation
-     SEGMENTATION__LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
-  codelist-labeling:
-    # This service is mostly configured via the file
-    # `../config/codelist/config.json`, only secrets are configured as
-    # environment variables.
-    environment:
-      LLM__API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
-  nominatim:
-    environment:
-      # Retrieve OSM data extracts for Germany instead of Belgium, as configured
-      # by default.
-      PBF_URL: https://download.geofabrik.de/europe/germany-latest.osm.pbf
-      # How many threads should be used to import (default: number of processing
-      # units available to the current process via nproc)
-      # Source: https://github.com/mediagis/nominatim-docker/blob/master/howto.md#configuration
-      # THREADS: 20
-
-  # Disable services for UC2 smart search
-  search:
-    entrypoint: ["echo", "Service search is disabled"]
-  elasticsearch:
-    entrypoint: ["echo", "Service elasticsearch is disabled"]
-  embedding:
-    entrypoint: ["echo", "Service embedding is disabled"]
-  municipality-linker:
-    entrypoint: ["echo", "Service municipality-linker is disabled"]
-  question-answering:
-    entrypoint: ["echo", "Service question-answering is disabled"]
-  frontend-smart-search:
-    entrypoint: ["echo", "Service frontend-smart-search is disabled"]
-
-  # Uncomment to disable the services related to the Human validation interface
-  # Alternatively, comment the validation.yml line in `docker-compose.yml`
-  # annotation-review:
-  #   entrypoint: ["echo", "Service annotation-review is disabled"]
-  # frontend-human-validator:
-  #   entrypoint: ["echo", "Service frontend-human-validator is disabled"]
-
-
-  # Uncomment to disable general data space services
-  # frontend-dcat:
-  #   entrypoint: ["echo", "Service frontend-dcat is disabled"]
-  # dcat:
-  #   entrypoint: ["echo", "Service dcat is disabled"]
-  # frontend-yasgui:
-  #   entrypoint: ["echo", "Service frontend-yasgui is disabled"]
-  # vc-issuer:
-  #   entrypoint: ["echo", "Service vc-issuer is disabled"]
-
-  # Uncomment to disable data quality manager service
-  # This service allows to generate reports about data quality, meant for
-  # internal monitoring
-  # report-generation:
-  #   entrypoint: ["echo", "Service report-generation is disabled"]
-
-  # Comment to enable general services
+  # Disable general data space services
+  vc-issuer:
+    restart: no
+    entrypoint: ["echo", "Service vc-issuer is disabled"]
   acmidm-login:
-    # This service is used to integrate with ACMIDM, a Belgian single sign-on
-    # solution based on Oauth2 and OpenID
+    restart: no
     entrypoint: ["echo", "Service acmidm-login is disabled"]
 
+  # Disable pipeline services:
+  frontend-harvesting:
+    restart: no
+    entrypoint: ["echo", "Service frontend-harvesting is disabled"]
+  login:
+    restart: no
+    entrypoint: ["echo", "Service login is disabled"]
+  job-controller:
+    restart: no
+    entrypoint: ["echo", "Service job-controller is disabled"]
+  scheduled-job-controller:
+    restart: no
+    entrypoint: ["echo", "Service scheduled-job-controller is disabled"]
+  annotation-job-splitter:
+    restart: no
+    entrypoint: ["echo", "Service annotation-job-splitter is disabled"]
+  harvest_singleton-job:
+    restart: no
+    entrypoint: ["echo", "Service harvest_singleton-job is disabled"]
+
+  resource-type-service:
+    restart: no
+    entrypoint: ["echo", "Service resource-type-service is disabled"]
+  harvest_diff:
+    restart: no
+    entrypoint: ["echo", "Service harvest_diff is disabled"]
+  harvest_sameas:
+    restart: no
+    entrypoint: ["echo", "Service harvest_sameas is disabled"]
+  oparl-to-eli:
+    restart: no
+    entrypoint: ["echo", "Service oparl-to-eli is disabled"]
+  lokaal-beslist-consumer:
+    restart: no
+    entrypoint: ["echo", "Service lokaal-beslist-consumer is disabled"]
+  decisions-ghent-filter:
+    restart: no
+    entrypoint: ["echo", "Service decisions-ghent-filter is disabled"]
+  oslo-eli-transformer:
+    restart: no
+    entrypoint: ["echo", "Service oslo-eli-transformer is disabled"]
+  json-to-eli:
+    restart: no
+    entrypoint: ["echo", "Service json-to-eli is disabled"]
+  entity-linking:
+    restart: no
+    entrypoint: ["echo", "Service entity-linking is disabled"]
+  pdf-scraper:
+    restart: no
+    entrypoint: ["echo", "Service pdf-scraper is disabled"]
+  pdf-content:
+    restart: no
+    entrypoint: ["echo", "Service pdf-content is disabled"]
+  apache-tika:
+    restart: no
+    entrypoint: ["echo", "Service apache-tika is disabled"]
+  question-answering:
+    restart: no
+    entrypoint: ["echo", "Service question-answering is disabled"]
+  nominatim:
+    restart: no
+    entrypoint: ["echo", "Service nominatim is disabled"]
+  named-entity-recognition:
+    restart: no
+    entrypoint: ["echo", "Service named-entity-recognition is disabled"]
+  ollama:
+    restart: no
+    entrypoint: ["echo", "Service ollama is disabled"]
+  codelist-labeling:
+    restart: no
+    entrypoint: ["echo", "Service codelist-labeling is disabled"]
+  search:
+    restart: no
+    entrypoint: ["echo", "Service search is disabled"]
+  elasticsearch:
+    restart: no
+    entrypoint: ["echo", "Service elasticsearch is disabled"]
+  embedding:
+    restart: no
+    entrypoint: ["echo", "Service embedding is disabled"]
+  municipality-linker:
+    restart: no
+    entrypoint: ["echo", "Service municipality-linker is disabled"]
+  frontend-smart-search:
+    restart: no
+    entrypoint: ["echo", "Service frontend-smart-search is disabled"]
+  annotation-review:
+    restart: no
+    entrypoint: ["echo", "Service annotation-review is disabled"]
+  frontend-human-validator:
+    restart: no
+    entrypoint: ["echo", "Service frontend-human-validator is disabled"]
+  report-generation:
+    restart: no
+    entrypoint: ["echo", "Service report-generation is disabled"]
+  policy-impact-report:
+    restart: no
+    entrypoint: ["echo", "Service policy-impact-report is disabled"]
+  frontend-policy-impact-report:
+    restart: no
+    entrypoint: ["echo", "Service frontend-policy-impact-report is disabled"]
 
   # LDES services for DCAT federation
   # Replace the values below to set the base URL used for your app's LDES feed.
   # Make sure this URL ends with `/ldes/`.
   ldes-delta-pusher:
     environment:
-      LDES_BASE: '<REPLACE-WITH-BASE-URL>'
+      LDES_BASE: "<REPLACE-WITH-BASE-URL>"
       # WRITE_INITIAL_STATE: "true"
   ldes-serve-feed:
     environment:
-      BASE_URL: '<REPLACE-WITH-BASE-URL>'
-
+      BASE_URL: "<REPLACE-WITH-BASE-URL>"
 
 # Uncomment to configure network exposed by app-letsencrypt
 # networks:


### PR DESCRIPTION
## description
disabled almost all services for freiburg so they only keep the dcat and datadumps services
## how to test
- `docker compose kill`
- change your .env file so it looks like this: `COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml:./docs/docker-compose.override.freiburg.yml`
- `docker compose up -d`
- run `docker compose ps -a` a few times to verify that most services are dead
- if not present, put a file like 20260625102039-codelists.ttl in ./data/datadumps
- view http://ds.localhost/datadumps/20260625102039-codelists.ttl in browser to make sure the download still works
- view and browse http://ds.localhost/ to make sure the dcat ui still works
- view http://ds.localhost/ldes/public/1 to verify the ldes still works
- run `curl -H 'Accept: text/turtle' https://ds.decide.lblod.info/dcat/catalogs` to verify the dcat ttl is still there 