### PR TITLE
fix agent uri filtering in HVT

### DIFF
--- a/config/annotation-review/config.ts
+++ b/config/annotation-review/config.ts
@@ -24,15 +24,15 @@ export default {
       `,
       // can use to filter annotations for a given target, need to fix the set of agents once we have final uris for them
       annotationFilter: `
-        VALUES ?agent {          
-          <http://data.gift/id/components/entity-extraction/v1.0.0>
-          <http://data.gift/id/components/segmentation/v1.0.0>
-          <http://lblod.data.gift/id/components/named-entity-linking/v1.0.0>
-          <http://lblod.data.gift/id/components/pdf-to-eli/v1.0.0>
+        FILTER NOT EXISTS {
+          VALUES ?hidden {
+            <http://lblod.data.gift/id/components/named-entity-linking/v1.0.0>
+            <http://lblod.data.gift/id/components/translation/v1.0.0>
+          }
+          ?agent <http://www.w3.org/ns/prov#specializationOf>  ?hidden.
         }
         FILTER(?type NOT IN (<http://www.w3.org/ns/locn#Address>, <https://data.vlaanderen.be/ns/adres#Straatnaam>, <http://www.wikidata.org/entity/Q2785216>, <http://www.wikidata.org/entity/Q123705> ))
-        FILTER(!BOUND(?typeClass) || ?typeClass NOT IN ( <http://mu.semte.ch/vocabularies/ext/AnnotationBody> ))
-        
+        FILTER(!BOUND(?typeClass) || ?typeClass NOT IN ( <http://mu.semte.ch/vocabularies/ext/AnnotationBody> ))        
       `,
       annotationPath: `
         ?annotation oa:hasTarget ?resource .
@@ -114,14 +114,6 @@ export default {
         FILTER(!BOUND(?typeClass) || ?typeClass NOT IN ( <http://mu.semte.ch/vocabularies/ext/AnnotationBody>, <http://mu.semte.ch/vocabularies/ext/NoMatchFound> ) )
         FILTER NOT EXISTS {
           ?object skos:inScheme <http://mu.semte.ch/vocabularies/ext/impact> .
-        }
-        {
-          ?action prov:wasAssociatedWith ?agent .
-          FILTER (?agent IN (<http://lblod.data.gift/id/components/codelist-annotation/v1.0.0>))
-        }
-        UNION {
-          ?annotation a ext:CorrectionAnnotation .
-          ?action prov:wasAssociatedWith ?agent .
         }
       `,
 

--- a/config/migrations/20260714120324-link-old-agents.sparql
+++ b/config/migrations/20260714120324-link-old-agents.sparql
@@ -1,0 +1,12 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.gift/id/components/segmentation/v1.0.0> prov:specializationOf <http://lblod.data.gift/id/components/segmentation/v1.0.0> .
+    <http://lblod.data.gift/id/components/impact-assessment/v1.0.0> prov:specializationOf <http://lblod.data.gift/id/components/impact-assessment/v1.0.0> .
+    <http://data.gift/id/components/named-entity-linking/v1.0.0> prov:specializationOf <http://lblod.data.gift/id/components/named-entity-linking/v1.0.0> .
+    <http://data.gift/id/components/entity-extraction/v1.0.0> prov:specializationOf <http://lblod.data.gift/id/components/entity-extraction/v1.0.0> .
+    <http://data.gift/id/components/translation/v1.0.0> prov:specializationOf <http://lblod.data.gift/id/components/translation/v1.0.0> .
+    <http://lblod.data.gift/id/components/codelist-annotation/v1.0.0> prov:specializationOf <http://lblod.data.gift/id/components/codelist-annotation/v1.0.0> .
+    <http://lblod.data.gift/id/components/pdf-to-eli/v1.0.0> prov:specializationOf <http://lblod.data.gift/id/components/pdf-to-eli/v1.0.0> .
+  }
+}


### PR DESCRIPTION
the agent filter was too restrictive, with the new versioned uris it doesn't hold up. 
This fixes the filter by filtering out agents based on what they are a specialization of

Test it by opening the hvt on a recent dataset and visiting http://human-validator.localhost/validate/87427a74-2bd8-47ba-93ea-7f138e22b22a