### PR TITLE
Feat/bump ner service

### DIFF
--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -128,7 +128,7 @@ services:
     labels:
       - logging=true
   named-entity-recognition:
-    image: semanticai/decide-geocoding-service:0.1.3
+    image: semanticai/decide-geocoding-service:0.1.4
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting

--- a/config/ner/config.json
+++ b/config/ner/config.json
@@ -8,7 +8,7 @@
     "method": "composite",
     "post_process": true,
     "validate_persons": true,
-    "min_confidence": null,
+    "min_confidence": 0.7,
     "labels": ["CITY", "DOMAIN", "HOUSENUMBERS", "INTERSECTION", "POSTCODE", "PROVINCE", "ROAD", "STREET"],
     "enable_refinement": true
   },


### PR DESCRIPTION
Summary
Bump the NER service to 0.1.4 to include:
- [faster segmentation](https://github.com/semantic-ai/decide-geocoding-service/commit/7a4988705c61fb6db68553e37e39e93d7d7fb644)
- [simple NER validation filters](https://github.com/semantic-ai/decide-geocoding-service/commit/ed49916cd0aaf1c287eee9000e1f48f49c43a8a8)
- [no more post-processing of legal_date entities](https://github.com/semantic-ai/decide-geocoding-service/commit/331d2cce36bbc22b2744a61b179843590a539ac9)