### PR TITLE
fix mock data not in the graph where mu-auth is looking for it

### DIFF
--- a/config/migrations/20260717063056-move-private-mock-data.sparql
+++ b/config/migrations/20260717063056-move-private-mock-data.sparql
@@ -1,0 +1,10 @@
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/organizations/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5> {
+    ?s ?p ?o.
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organizations/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5/Decide-gebruiker> {
+    ?s ?p ?o.
+  }
+}


### PR DESCRIPTION
see query for organization-member party collection: it doesn't use the roles to construct the resulting graph: https://github.com/lblod/app-decide/blob/124166aed9b0dc077a04ca634645b3fdfe3f09b6/config/authorization/config.ttl#L121

This data is queried when using the non-public sparql endpoint, /api/private/sparql and asking for info about         <http://data.lblod.info/id/works/348bba93-d3eb-49b9-9d03-3e056b72cfda>

```
curl --request POST \
  --url http://localhost/api/private/sparql \
  --header 'Authorization: Bearer fakey' \
  --header 'dsp-role: http://data.lblod.info/id/bestuurseenheden/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5:bought' \
  --data 'query=PREFIX dcat: <http://www.w3.org/ns/dcat#>
  SELECT * WHERE {
    <http://data.lblod.info/id/works/348bba93-d3eb-49b9-9d03-3e056b72cfda> ?p ?o.
  } limit 10'
```

in override
```
dsp-auth-wrapper:
    environment:
      API_KEY: fakey
```
