### PR TITLE
fix: bump geocoding service version 

### DIFF
--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -128,7 +128,7 @@ services:
     labels:
       - logging=true
   named-entity-recognition:
-    image: semanticai/decide-geocoding-service:0.1.4
+    image: semanticai/decide-geocoding-service:0.1.5
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting


### PR DESCRIPTION
Bump geocoding service version to include the fix  in case the LLM did not provide the right starting line number