### PR TITLE
fixes from issues during call bamberg

### DIFF
--- a/compose/policy-impact-report.yml
+++ b/compose/policy-impact-report.yml
@@ -5,7 +5,7 @@ x-logging: &default-logging
     max-file: '3'
 services:
   policy-impact-report:
-    image: lblod/policy-impact-report-service:0.0.2
+    image: lblod/policy-impact-report-service:0.0.3
     labels:
       - 'logging=true'
     restart: always

--- a/compose/policy-impact-report.yml
+++ b/compose/policy-impact-report.yml
@@ -5,7 +5,7 @@ x-logging: &default-logging
     max-file: '3'
 services:
   policy-impact-report:
-    image: lblod/policy-impact-report-service:0.0.1
+    image: lblod/policy-impact-report-service:0.0.2
     labels:
       - 'logging=true'
     restart: always

--- a/compose/policy-impact-report.yml
+++ b/compose/policy-impact-report.yml
@@ -11,7 +11,7 @@ services:
     restart: always
     logging: *default-logging
   frontend-policy-impact-report:
-    image: lblod/frontend-decide-policy-impact-report:0.0.2
+    image: lblod/frontend-decide-policy-impact-report:0.0.3
     labels:
       - 'logging=true'
     restart: always

--- a/config/annotation-review/config.ts
+++ b/config/annotation-review/config.ts
@@ -110,6 +110,12 @@ export default {
       `,
       // can use to filter annotations for a given target, need to fix the set of agents once we have final uris for them
       annotationFilter: `
+        FILTER NOT EXISTS {
+          VALUES ?hidden {
+            <http://lblod.data.gift/id/components/codelist-labeling/v1.0.0/impact_annotator>
+          }
+          ?agent <http://www.w3.org/ns/prov#specializationOf>  ?hidden.
+        }
         ?object a skos:Concept .
         FILTER(!BOUND(?typeClass) || ?typeClass NOT IN ( <http://mu.semte.ch/vocabularies/ext/AnnotationBody>, <http://mu.semte.ch/vocabularies/ext/NoMatchFound> ) )
         FILTER NOT EXISTS {

--- a/config/authorization/config.ttl
+++ b/config/authorization/config.ttl
@@ -56,6 +56,7 @@ ext:decideAuthorizationPolicy a odrl:Set ;
     ext:allowReadOsloOrgsForHumanValidation ,
     ext:allowReadForHumanValidation ,
     ext:allowQuestionAnsweringReadForHumanValidation,
+    ext:allowReadHarvestingForHumanValidation ,
     ext:allowWriteForHumanValidation ,
     ext:allowReadForQuestionAnswering ,
     ext:allowWriteForQuestionAnswering ,
@@ -276,6 +277,13 @@ ext:allowReadOrgsForSession a odrl:Permission ;
 ext:allowReadForHumanValidation a odrl:Permission ;
   odrl:action odrl:read ;
   odrl:target ext:decideHumanValidationSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadHarvestingForHumanValidation a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestingSlice ;
   odrl:assigner ext:decideSystem ;
   odrl:assignee ext:publicParty  ;
   ext:scope "http://services.semantic.works/annotation-review-service" .

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -77,6 +77,10 @@ defmodule Dispatcher do
     Proxy.forward conn, [], "http://database:8890/sparql"
   end
 
+  match "/sparql", %{ accept: [:any], layer: :sparql } do
+    Proxy.forward conn, [], "http://database:8890/sparql"
+  end
+
   match "/api/private/sparql", %{ accept: [:any], layer: :sparql } do
     Proxy.forward conn, [], "http://dsp-auth-wrapper/sparql"
   end

--- a/config/municipality-linker/config.ts
+++ b/config/municipality-linker/config.ts
@@ -20,5 +20,13 @@ export const municipalityLink = `
       FILTER NOT EXISTS {
         ?original <http://purl.org/linguistics/gold/translation> ?decision .
       }
+    } UNION {
+      ?task <http://purl.org/dc/terms/isPartOf> ?job .
+      ?task <http://redpencil.data.gift/vocabularies/tasks/inputContainer> / <http://redpencil.data.gift/vocabularies/tasks/hasResource> ?target .
+      ?job <http://mu.semte.ch/vocabularies/ext/shapeForTargets> / <http://www.w3.org/ns/shacl#targetNode> ?decision .
+      ?decision a eli:Expression.
+      FILTER NOT EXISTS {
+        ?original <http://purl.org/linguistics/gold/translation> ?decision .
+      }
     }
   `;

--- a/docs/docker-compose.override.bamberg.yml
+++ b/docs/docker-compose.override.bamberg.yml
@@ -89,6 +89,11 @@ services:
       GENERATION_MODEL: "<REPLACE-WITH-MODEL>"
       GENERATION_API_KEY: "<REPLACE-WITH-API-KEY-IN-OVERRIDE-FILE>"
 
+  frontend-policy-impact-report:
+    environment:
+      # e.g. "http://human-validator.localhost"
+      EMBER_HVT_BASE_URL: "<REPLACE-WITH-HVT-URL-LOCATION>"
+
 
   # Uncomment to disable the services related to the Human validation interface
   # Alternatively, comment the validation.yml line in `docker-compose.yml`


### PR DESCRIPTION
## Description

Fixes for issues discovered during call with bamberg
- expressions generated by json-to-eli were not found by municipality linker
- /sparql endpoint in harvesting selfservice frontend is not configurable and not linked in dispatcher right now, also expose it like we do /api/sparql, this goes to mu-auth obviously
- add example on how to override the hvt url in pir frontend
- some ai tools write annotation info to harvesting graph (like ai agent info), this is also needed for filtering in annotation review service
- policy impact report was not bumped yet so it showed weird numbers on empty dataset
- extra agent filter in annotation-review service config because impact annotations have 2 agents linked, resulting in duplicates
- bump policy-impact-report so the positive/negative impact decision counts are shown properly 
## How to test
- run json-to-eli and see that the resulting expressions now get an ext:owningBody
- use the harvesting selfservice frontend's sparql interface
- try out the override in the bamberg docker compose override and click though in PIR frontend
- use the bamberg annotation data and see that we get locations in the hvt for e.g. http://human-validator.localhost/validate/b3ead208-8435-11f1-8a0e-8b975e8b6844 and we don't see skos:exactMatch annotations
- open PIR with no data loaded
- open HVT codelist labeling annotations from bamberg and see there are no more duplicates 
- open PIR with bamberg data loaded and check  positive/negative impact decision counts are shown properly 