### PR TITLE
fix(json-to-eli): use sudo queries instead of scopes

### DIFF
--- a/compose/json.yml
+++ b/compose/json.yml
@@ -6,8 +6,6 @@ x-logging: &default-logging
 services:
   json-to-eli:
     image: lblod/decide-json-to-eli-service:0.0.2
-    environment:
-      DEFAULT_MU_AUTH_SCOPE: http://services.semantic.works/decide-json-to-eli-service
     labels:
       - 'logging=true'
     restart: always

--- a/compose/json.yml
+++ b/compose/json.yml
@@ -5,7 +5,7 @@ x-logging: &default-logging
     max-file: '3'
 services:
   json-to-eli:
-    image: lblod/decide-json-to-eli-service:0.0.2
+    image: lblod/decide-json-to-eli-service:0.0.3
     labels:
       - 'logging=true'
     restart: always

--- a/config/authorization/config.ttl
+++ b/config/authorization/config.ttl
@@ -74,10 +74,7 @@ ext:decideAuthorizationPolicy a odrl:Set ;
     ext:allowWriteForSession ,
     ext:allowReadPublicForSession ,
     ext:allowReadOrgsForSession ,
-    ext:allowPublicReadForAuthz ,
-    ext:allowWritePdfForJsonToEli ,
-    ext:allowReadForHarvestingJsonToEli ,
-    ext:allowWriteForHarvestingJsonToEli .
+    ext:allowPublicReadForAuthz .
 
 # Parties for groups
 ext:decideSystem a odrl:Party ;
@@ -387,26 +384,6 @@ ext:allowReadAiSliceForQuestionAnswering a odrl:Permission ;
   odrl:assignee ext:publicParty ;
   ext:scope "http://services.semantic.works/decide-question-answering-service" .
 
-ext:allowWritePdfForJsonToEli a odrl:Permission ;
-  odrl:action odrl:modify ;
-  odrl:target ext:decideHarvestedPdfSlice ;
-  odrl:assignee ext:publicParty ;
-  ext:scope "http://services.semantic.works/decide-json-to-eli-service" .
-
-ext:allowReadForHarvestingJsonToEli a odrl:Permission ;
-  odrl:action odrl:read ;
-  odrl:target ext:decideHarvestingSlice ;
-  odrl:assigner ext:decideSystem ;
-  odrl:assignee ext:publicParty ;
-  ext:scope "http://services.semantic.works/decide-json-to-eli-service" .
-
-ext:allowWriteForHarvestingJsonToEli a odrl:Permission ;
-  odrl:action odrl:modify ;
-  odrl:target ext:decideHarvestingSlice ;
-  odrl:assigner ext:decideSystem ;
-  odrl:assignee ext:publicParty ;
-  ext:scope "http://services.semantic.works/decide-json-to-eli-service" .
-
 # Assets (SHACL shapes) for type specifications
 ext:BesluitAdministrativeUnitAsset a odrl:Asset, sh:NodeShape ;
   odrl:partOf ext:decidePublicSlice ,
@@ -631,7 +608,7 @@ ext:ExtReviewAnnotationAsset a odrl:Asset, sh:NodeShape ;
 ext:ExtAnnotationTargetAsset a odrl:Asset, sh:NodeShape ;
   odrl:partOf ext:decideHumanValidationSlice ;
   sh:targetClass ext:AnnotationTarget .
-  
+
 ext:ExtCorrectionAnnotationAsset a odrl:Asset, sh:NodeShape ;
   odrl:partOf ext:decideHumanValidationSlice ;
   sh:targetClass ext:CorrectionAnnotation .


### PR DESCRIPTION
This service reacts to delta messages which causes issues with using scopes.
Work around this by using sudo queries in the service instead.


## How to test

0. Checkout this PR's branch
1. Restart the database to load its modified configuration: `docker compose restart database`


## Related PRs

- [#5](https://github.com/lblod/decide-json-to-eli-service/pull/5) updates the json-to-eli service to use sudo queries