### PR TITLE
chore: bump json-to-eli service

### DIFF
--- a/compose/json.yml
+++ b/compose/json.yml
@@ -5,7 +5,7 @@ x-logging: &default-logging
     max-file: '3'
 services:
   json-to-eli:
-    image: lblod/decide-json-to-eli-service:0.0.3
+    image: lblod/decide-json-to-eli-service:0.0.4
     labels:
       - 'logging=true'
     restart: always


### PR DESCRIPTION
Latest release of this service fixes a bug, see [#6](https://github.com/lblod/decide-json-to-eli-service/pull/6) for more details.