### PR TITLE
fix xsd date

### DIFF
--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -129,7 +129,7 @@ services:
     labels:
       - logging=true
   named-entity-recognition:
-    image: semanticai/decide-geocoding-service:0.2.1
+    image: semanticai/decide-geocoding-service:0.2.2
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/20260727064023-fix-xsd-date.sparql
+++ b/config/migrations/20260727064023-fix-xsd-date.sparql
@@ -1,0 +1,19 @@
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+DELETE {
+  GRAPH ?g {
+    ?body rdf:object ?date.
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?body rdf:object ?correctDate.
+  }
+}WHERE {
+  ?s a oa:Annotation.
+  ?s oa:hasBody ?body.
+  GRAPH ?g {
+    ?body rdf:object ?date.
+  }
+  FILTER(datatype(?date) = xsd:Date)
+  BIND(xsd:date(STR(?date)) AS ?correctDate)
+} 


### PR DESCRIPTION
# DO NOT MERGE BEFORE https://github.com/semantic-ai/decide-geocoding-service/pull/60
## Description

An AI service invented the xsd:Date datatype. This brings it back to the official xsd:date datatype.

## How to test

Run this query before and after, shouldn't return any results after:

```
  SELECT *
  WHERE {
    ?s a oa:Annotation.
    ?s oa:hasBody ?body.
    GRAPH ?g {
      ?body rdf:object ?date.
    }
    FILTER(datatype(?date) = xsd:Date)
    BIND(xsd:date(STR(?date)) AS ?correctDate)
  } limit 10
```
