### PR TITLE
Remove UC2 from validation dataset

### DIFF
--- a/scripts/project/publish_dataset/queries/human-validations.sparql
+++ b/scripts/project/publish_dataset/queries/human-validations.sparql
@@ -10,9 +10,6 @@
       ?originalAnnotation a ext:downloadResource .
       ?originalBody a ext:downloadResource .
       ?specificResource a ext:downloadResource .
-      ?quotation a ext:downloadResource .
-      ?answer a ext:downloadResource .
-      ?question a ext:downloadResource .
       ?selector a ext:downloadResource .
     }
   }
@@ -35,24 +32,6 @@
       ?originalTarget oa:hasSource ?expression .
       ?originalTarget oa:hasSelector ?selector .
       bind(?originalTarget as ?specificResource) .
-    }
-    union {
-      # Quotations only have an expression as source, no selector
-      ?originalTarget a schema:Quotation .
-      bind(?originalTarget as ?quotation) .
-      
-      ?quotation oa:hasSource ?expression .
-      ?answer schema:citation ?quotation .
-      ?question schema:suggestedAnswer ?answer .
-    }
-    union {
-      # Answers have a link with expression(s) through its quotations
-      ?originalTarget a schema:Answer .
-      bind(?originalTarget as ?answer)
-
-      ?quotation oa:hasSource ?expression .
-      ?answer schema:citation ?quotation .
-      ?question schema:suggestedAnswer ?answer .
     }
 
     {


### PR DESCRIPTION
Removes UC2 from dataset export by removing `schema:Answer` and `schema:Question` and `schema:Quotation` from the `human-validations.sparql` query.

# how to test

- Checkout this branch
- Run the publish dataset script: `mu script project-scripts publish-dataset --dataset human-validations --org abb` . Abb org is used, as this does not add an organization filter, so all data is outputted. When ready, you should a log `DCAT Dataset 'human-validations' written to <http://mu.semte.ch/graphs/public>.
[Pipeline] Finished. DCAT catalog + dataset written for dataset 'human-validations' (organization: 'abb') to <http://mu.semte.ch/graphs/public>.`
- Checkout the datadump that is created in the `./data/datadumps`. Use ctrl+f to search for `schema:Answer`, `schema:Quotation`, `schema:Question`. None should be found.

# Remark

Before, data from UC2 also didn't get exported, because the human validation annotation targets the question, answer, or quotation directly. There is no `?originalAnnotation` in uc2