### PR TITLE
LBRON-1709 | Cleanup previous dataset import

### DIFF
--- a/config/migrations/20260728091200-remove-not-owned-datasets-from-previous-migration.sparql
+++ b/config/migrations/20260728091200-remove-not-owned-datasets-from-previous-migration.sparql
@@ -1,0 +1,99 @@
+prefix agent: <http://data.lblod.info/id/agents/>
+prefix dataset: <http://data.lblod.info/id/datasets/>
+prefix distribution: <http://data.lblod.info/id/distributions/>
+prefix service: <http://data.lblod.info/id/services/>
+
+delete {
+  graph ?g {
+    ?subject ?p ?o .
+  }
+  graph ?go {
+    ?s ?sp ?subject .
+  }
+}
+where {
+  values ?subject {
+    agent:7365f73a-b57c-4999-aa8b-61464d9d3c6f # more! software GmbH
+    agent:658900ce-63cf-4d45-8fd5-a67ed8deab2c # Municipality of Freiburg
+    agent:f45c1220-b250-4b93-8a8a-3e7e4a12a467 # Agentschap Binnenlands Bestuur
+    agent:7cb46783-0ca2-41a2-b28c-248b99e752e4 # Agentschap Binnenlands Bestuur (DECIDe)
+    agent:436c5bce-8380-401e-8027-f34ef4acd97e # Lokaal Beslist
+    agent:945e9df0-c9e6-4f5c-a249-34075169e68d # Loket Lokaal Bestuur
+    # Lokaal Beslist Harvester 0
+      dataset:2bb49e25-feb1-4daf-b98a-6c274e7d6d7d
+      distribution:4697a3e9-9225-4ca1-a17c-0df585b4f872
+      service:df87f118-165c-468d-b558-99f5c324d334
+    # Lokaal Beslist Harvester 1
+      dataset:cf4d74f5-f39b-4193-a79c-6b46c8e3c9a6
+      distribution:3e9974a1-2182-404b-b60a-84a64468df31
+      service:57638b91-d88b-44cb-9664-61d108bb92e7
+    # Lokaal Beslist Harvester 2
+      dataset:0b2ad45a-eccf-45ac-874d-8b498a172772
+      distribution:e5f475b5-c6d3-4ff2-b8fc-0a81003138a0
+      service:706a5fda-ef6e-496e-a312-15a0620efe12
+    # Lokaal Beslist Harvester 3
+      dataset:f7a4bbb3-1fef-4975-9049-ee933cfce30e
+      distribution:19bada3c-fc39-4524-a692-d45e735f578f
+      service:ec5feb51-9108-4c35-adef-d799f64bab9d
+    # Open Proces Huis procesdata
+      dataset:74c12f17-f0eb-4bf2-8390-0d21655f00e3
+      distribution:ad94e41e-a790-44bc-8602-e1fe0c7bc1b0
+      service:7333d62b-bd34-4063-ad34-28ec22a098b5
+    # Ghent Municipal Decisions Roadblocks Classification
+      dataset:dd91b174-e9bb-4d33-8732-ed064a828b60
+      distribution:f27a58aa-5cbf-4612-b3d0-a4d49100153f
+    # lama3 ABB Instruct
+      dataset:2e1d52d9-2509-4b60-ac5a-0307897d64ef
+      distribution:4ed47dd1-aa35-4f94-b751-c0984349908c
+    # ABB DECIDe SDGs Antwerp
+      dataset:6aaa542d-410c-4150-bcfd-e5526eab87f4
+      distribution:6d5607a1-e1b3-4259-b186-760d8fef7da3
+    # ABB DECIDe title extraction instruct
+      dataset:3d79b143-4009-451a-8b80-423da944d9a8
+      distribution:b8b63c96-f5ce-496a-937e-7406f6aa1b91
+    # Flanders NER and Segmentation dataset
+      dataset:6b65a734-7d22-4486-97e3-c7eafc7341d5
+      distribution:a9233283-4233-41b0-a4e4-ab470c49a6f6
+    # Freiburg NER and Segmentation dataset
+      dataset:38fd6817-f185-478d-9e21-12d6a694834c
+      distribution:66b310c8-4d2b-4f8f-a292-c1882f939e6c
+    # Bamberg NER and Segmentation dataset
+      dataset:2ba4d174-e492-4bf2-b3a6-425f7afa51bf
+      distribution:7125af8b-f298-44a5-9c5f-c3db1b296fbd
+    # Combined translated dataset
+      dataset:b0d10410-8bd0-408d-81d1-5794296e3e1b
+      distribution:ab53349d-155c-4ed4-ad5a-27404488b69b
+    # OSLO besluitdata
+      dataset:16a89d3f-b75d-4dc8-bee8-69089f734c27
+      distribution:7ccb4d96-a5fe-466b-8d54-74dcd318db31
+    # ELI besluitdata Gent
+      dataset:93951be6-e452-4579-807b-df5c969e333e
+      distribution:c321d079-aa58-4732-a222-c3e9a76cdc8f
+    # Shared internal SPARQL endpoint service (serves the two above + Freiburg below)
+      service:0993dd37-87d7-4c20-894b-f7e3ffc87b7c
+    # Decisions from Freiburg (has 3 distributions / 2 extra services)
+      dataset:ead64000-2c7d-4fcc-a255-fd1c3451f956
+      distribution:33f42ce6-3278-438f-9463-37a9ab17b096
+      distribution:743d147f-7079-4425-aa5b-0351dde216f4
+      service:e27bea64-2c54-4dc0-8c6d-a6d4a1ed609b
+      distribution:46321676-74d9-4ab9-be29-83612ab7ec51
+      service:a04a2727-d097-4297-93cc-1b3bfe7bf5e2
+    # Freiburg local decisions (source doc dataset)
+      dataset:3840171f-daf5-4efe-bf42-e7d511e6a1c1
+      distribution:db4e1b76-1a09-45fa-99be-32ddc5840a37
+    # Bamberg local decisions (source doc dataset)
+      dataset:8a84f8a5-613a-45d0-bd43-e430dd3516ce
+      distribution:7661627c-3cae-4991-bbdc-1f0a3f633781
+  }
+  {
+    graph ?g {
+      ?subject ?p ?o .
+    }
+  }
+  union
+  {
+    graph ?go {
+      ?s ?sp ?subject .
+    }
+  }
+}


### PR DESCRIPTION
## Description

We need to cleanup the datasets in our database. We did a previous ttl insert for our own datasets but not all of them must stay in the project.

## How to test

- all not owned datasets are removed from the database
- generate the dcat-datasets from the script and see if everything turns out as expected https://github.com/lblod/app-decide/blob/development/scripts/project/publish_dataset/README.md

## Attachments

<img width="1018" height="905" alt="image" src="https://github.com/user-attachments/assets/bd918c89-2f83-4a54-b4ab-1534869b5dbb" />
 

## Links to other PR's

- https://github.com/lblod/frontend-decide-dcat/pull/2
- https://github.com/lblod/dcat-service/pull/5