### PR TITLE
feat: add job splitter to PDF pipelines

### DIFF
--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -58,7 +58,7 @@ services:
     restart: always
     logging: *default-logging
   pdf-content:
-    image: semanticai/decide-pdf-content-extraction:0.2.0
+    image: semanticai/decide-pdf-content-extraction:0.2.1
     environment:
       APACHE_TIKA_URL: 'http://apache-tika:9998/tika'
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting

--- a/compose/pipeline.yml
+++ b/compose/pipeline.yml
@@ -62,7 +62,7 @@ services:
     restart: always
     logging: *default-logging
   annotation-job-splitter:
-    image: lblod/annotation-job-splitter-service:0.0.5
+    image: lblod/annotation-job-splitter-service:0.0.6
     restart: always
     logging: *default-logging
     volumes:

--- a/config/annotation-job-splitter/config.ts
+++ b/config/annotation-job-splitter/config.ts
@@ -66,5 +66,17 @@ export default {
           },
         ],
       },
+    'http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/pdf-to-enriched':
+      {
+        taskConfiguration: [
+          {
+            currentOperation:
+              'http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-enriched-scraping',
+            nextOperation:
+              'http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping',
+            harvestingCollection: true,
+          },
+        ],
+      },
   },
 };

--- a/config/annotation-job-splitter/config.ts
+++ b/config/annotation-job-splitter/config.ts
@@ -76,6 +76,12 @@ export default {
               'http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping',
             harvestingCollection: true,
           },
+          {
+            currentOperation:
+              'http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-enriched-translating',
+            nextOperation:
+              'http://lblod.data.gift/id/jobs/concept/TaskOperation/translating',
+          },
         ],
       },
   },

--- a/config/annotation-job-splitter/config.ts
+++ b/config/annotation-job-splitter/config.ts
@@ -54,5 +54,17 @@ export default {
           },
         ],
       },
+    'http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/pdf-to-eli':
+      {
+        taskConfiguration: [
+          {
+            currentOperation:
+              'http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-eli-scraping',
+            nextOperation:
+              'http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping',
+            harvestingCollection: true,
+          },
+        ],
+      },
   },
 };

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -78,23 +78,29 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-to-eli",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/translating",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-enriched-translating",
         "nextIndex": "4"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-enriched-translating",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/translating",
+        "nextIndex": "5",
+        "external": true
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/translating",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/segmenting",
-        "nextIndex": "5"
+        "nextIndex": "6"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/segmenting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
-        "nextIndex": "6"
+        "nextIndex": "7"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/named-entity-linking",
-        "nextIndex": "7"
+        "nextIndex": "8"
       }
     ]
   },

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -37,13 +37,19 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-eli-scraping",
         "nextIndex": "1"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-eli-scraping",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping",
+        "nextIndex": "2",
+        "external": true
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-to-eli",
-        "nextIndex": "2"
+        "nextIndex": "3"
       }
     ]
   },

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -62,33 +62,39 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-enriched-scraping",
         "nextIndex": "1"
+      },
+      {
+        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-enriched-scraping",
+        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping",
+        "nextIndex": "2",
+        "external": true
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-to-eli",
-        "nextIndex": "2"
+        "nextIndex": "3"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-to-eli",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/translating",
-        "nextIndex": "3"
+        "nextIndex": "4"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/translating",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/segmenting",
-        "nextIndex": "4"
+        "nextIndex": "5"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/segmenting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
-        "nextIndex": "5"
+        "nextIndex": "6"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/named-entity-linking",
-        "nextIndex": "6"
+        "nextIndex": "7"
       }
     ]
   },


### PR DESCRIPTION
The PDF pipelines currently create a single task per step.  Such tasks may cover multiple PDFs and many decisions.  Consequently, it difficult to selectively restart, for example, the enrichment for a specific decision after it failed.  This would require either restarting the task as a whole, redoing to work for all resources, or manually starting a new job.

Therefore, this PR adds the annotation-job-splitter service to the existing PDF pipelines.  This splits the tasks into smaller ones, e.g. per ELI expression, that can be more easily restarted.


## Approach
The app contains to pipelines that involve PDFs: `pdf-to-eli` and `pdf-to-enriched`.  For both we add a new split task in between the initial `singleton-job` and the `pdf-scraping` task.  This split task allows the job-splitter service to create one task per URL the user provided as input.

Furthermore, the `pdf-to-enriched` job is extended with a second split task between its `pdf-to-eli` step and `translating` step.  This allows the job-splitter service to create a `translating` task per ELI Expression that was extracted in the preceding step.  This way the job-controller service will take of creating the appropriate follow-up enrichment tasks, similar to other enrichment pipelines.


## How to test
0. Check out the branch for this PR.
1. Pull the new version of the `annotation-job-splitter` and re-up the service.
2. Restart the `job-controller` and `annotation-job-splitter` services such that they load the modified configurations: `docker compose restart job-controller annotation-job-splitter`.
3. Launch the harvesting dashboard from [#73](https://github.com/lblod/frontend-harvesting-self-service/pull/73) and log in.
4. Create jobs involving PDF harvesting:
   - "Harvest PDFs from Website URL & Publish as ELI" and "Harvest PDFs from Website URL, Publish as ELI and Enrich"
   - Experiment with the number of URLs you provide
5. Check whether the appropriate amount of follow-up tasks is created.


## Related PRs
- Added functionality in annotation-job-service: [#9](https://github.com/lblod/annotation-job-splitter-service/pull/9)
- Extend the harvesting dashboard to add target shapes to PDF jobs: [#73](https://github.com/lblod/frontend-harvesting-self-service/pull/73)
- Extend pdf-content-extraction-service to add target shape to job: [#32](https://github.com/semantic-ai/decide-pdf-content-extraction/pull/34)


## TODO
- [x] Bump `pdf-content` to version containing the functionality added in [#32](https://github.com/semantic-ai/decide-pdf-content-extraction/pull/34)

## Related tickets
- LBRON-1720