### PR TITLE
Fix RMZ codelist URI + add time annotations to export

### DIFF
--- a/scripts/project/publish_dataset/config.json
+++ b/scripts/project/publish_dataset/config.json
@@ -67,7 +67,7 @@
                 "uri": "https://opendata.smartcitybamberg.de/decide/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7",
                 "name": "City of Bamberg"
             },
-            "organizationFilter": "values ?participant { <https://opendata.smartcitybamberg.de/decide/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7> }"
+            "organizationFilter": "values ?organization { <https://opendata.smartcitybamberg.de/decide/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7> }"
         },
         "gent": {
             "catalog_uri": "http://data.lblod.info/id/catalogs/80fb699a-0d95-4089-843d-79c89138cdb7",
@@ -76,7 +76,7 @@
                 "uri": "http://data.lblod.info/id/bestuurseenheden/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5",
                 "name": "City of Gent"
             },
-            "organizationFilter": "values ?participant { <http://data.lblod.info/id/bestuurseenheden/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5> }"
+            "organizationFilter": "values ?organization { <http://data.lblod.info/id/bestuurseenheden/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5> }"
         },
         "freiburg": {
             "catalog_uri": "http://data.lblod.info/id/catalogs/9c8b1e5a-9c3d-4f0b-8c7e-2a1b2c3d4e5f",
@@ -85,7 +85,7 @@
                 "uri": "https://ris.freiburg.de/oparl/body/FR",
                 "name": "City of Freiburg"
             },
-            "organizationFilter": "values ?participant { <https://ris.freiburg.de/oparl/body/FR> }"
+            "organizationFilter": "values ?organization { <https://ris.freiburg.de/oparl/body/FR> }"
         },
         "abb": {
             "catalog_uri": "http://data.lblod.info/id/catalogs/3bea809d-bfdb-485e-a7b2-10c6dea96af9",

--- a/scripts/project/publish_dataset/config.json
+++ b/scripts/project/publish_dataset/config.json
@@ -15,11 +15,28 @@
             "output_file_name": "rmz",
             "sparql_file": "./queries/rmz.sparql",
             "interesting_variables": [
-            "locationAnnotation",
             "rmzAnnotation",
+            "locationAnnotation",
+            "locationTarget",
+            "locationSelector",
+            "locationStatement",
             "location",
             "geometry",
-            "selector"
+            "dateApplicabilityAnnotation",
+            "dateApplicabilityStatement",
+            "dateApplicabilityTarget",
+            "dateApplicabilitySelector",
+            "dateApplicabilityObject",
+            "normativeProvisionAnnotation",
+            "normativeProvisionStatement",
+            "normativeProvision",
+            "normativeProvisionTarget",
+            "normativeProvisionSelector",
+            "impactPeriodAnnotation",
+            "impactPeriodStatement",
+            "impactPeriod",
+            "impactPeriodTarget",
+            "impactPeriodSelector"
             ]
         },
         "expressions": {

--- a/scripts/project/publish_dataset/queries/rmz.sparql
+++ b/scripts/project/publish_dataset/queries/rmz.sparql
@@ -22,6 +22,7 @@ insert {
     ?dateApplicabilityStatement a ext:downloadResource .
     ?dateApplicabilityTarget a ext:downloadResource .
     ?dateApplicabilitySelector a ext:downloadResource .
+    ?dateApplicabilityObject a ext:downloadResource .
     ?normativeProvisionAnnotation a ext:downloadResource .
     ?normativeProvisionStatement a ext:downloadResource .
     ?normativeProvision a ext:downloadResource .
@@ -68,7 +69,15 @@ where {
     ?dateApplicabilityTarget oa:hasSelector ?dateApplicabilitySelector ;
       oa:hasSource ?expression .
 
-    ?dateApplicabilityStatement rdf:predicate eli:date_applicability .
+    {
+    ?dateApplicabilityStatement rdf:predicate eli:date_applicability ;
+        rdf:object ?dateApplicability .
+      FILTER(ISLITERAL(?dateApplicability))
+    } UNION {
+      ?dateApplicabilityStatement rdf:predicate eli:date_applicability ;
+        rdf:object ?dateApplicabilityObject .
+      FILTER(!ISLITERAL(?dateApplicabilityObject))
+    }
   }
 
   optional {

--- a/scripts/project/publish_dataset/queries/rmz.sparql
+++ b/scripts/project/publish_dataset/queries/rmz.sparql
@@ -6,6 +6,8 @@ prefix org: <http://www.w3.org/ns/org#>
 prefix eli: <http://data.europa.eu/eli/ontology#>
 prefix oa: <http://www.w3.org/ns/oa#>
 prefix locn: <http://www.w3.org/ns/locn#>
+prefix dct: <http://purl.org/dc/terms/>
+prefix omgeving: <http://data.vlaanderen.be/ns/omgeving#>
 
 insert {
   graph <http://mu.semte.ch/graphs/tmp-export> {
@@ -14,6 +16,13 @@ insert {
     ?location a ext:downloadResource .
     ?geometry a ext:downloadResource .
     ?selector a ext:downloadResource .
+    ?dateApplicabilityAnnotation a ext:downloadResource .
+    ?normativeProvisionAnnotation a ext:downloadResource .
+    ?normativeProvisionStatement a ext:downloadResource .
+    ?normativeProvision a ext:downloadResource .
+    ?impactPeriodAnnotation a ext:downloadResource .
+    ?impactPeriodStatement a ext:downloadResource .
+    ?impactPeriod a ext:downloadResource .
   }
 }
 where {
@@ -21,7 +30,7 @@ where {
 
   ?rmzAnnotation oa:hasBody ?rmzConcept .
   ?rmzAnnotation oa:hasTarget ?expression .
-  ?rmzConcept skos:inScheme <http://data.lblod.gift/id/conceptscheme/restricted-mobility-zone-types> .
+  ?rmzConcept skos:inScheme <http://data.lblod.gift/id/conceptscheme/restricted-mobility-zone-simple> .
 
   optional {
     ?locationAnnotation a oa:Annotation .  
@@ -31,6 +40,32 @@ where {
     ?locationAnnotation oa:hasTarget ?locationTarget .
     ?locationTarget oa:hasSource ?expression .
     ?locationTarget oa:hasSelector ?selector .
+  }
+
+  optional {
+    ?dateApplicabilityAnnotation a oa:Annotation ;
+        oa:hasBody/rdf:predicate eli:date_applicability ;
+        oa:hasTarget ?expression .
+  }
+
+  optional {
+    ?normativeProvisionAnnotation a oa:Annotation ;
+        oa:hasBody ?normativeProvisionStatement ;
+        oa:hasTarget ?expression .
+
+    ?normativeProvisionStatement rdf:predicate eli:realizes ;
+        rdf:object ?normativeProvision .
+    
+    ?normativeProvision a omgeving:NormativeProvision .
+  }
+
+  optional {
+    ?impactPeriodAnnotation a oa:Annotation ;
+        oa:hasBody ?impactPeriodStatement ;
+        oa:hasTarget ?expression .
+
+    ?impactPeriodStatement rdf:predicate dct:extent ;
+        rdf:object ?impactPeriod .    
   }
 
   {

--- a/scripts/project/publish_dataset/queries/rmz.sparql
+++ b/scripts/project/publish_dataset/queries/rmz.sparql
@@ -7,22 +7,31 @@ prefix eli: <http://data.europa.eu/eli/ontology#>
 prefix oa: <http://www.w3.org/ns/oa#>
 prefix locn: <http://www.w3.org/ns/locn#>
 prefix dct: <http://purl.org/dc/terms/>
-prefix omgeving: <http://data.vlaanderen.be/ns/omgeving#>
+prefix omgeving: <https://data.vlaanderen.be/ns/omgevingsvergunning#>
 
 insert {
   graph <http://mu.semte.ch/graphs/tmp-export> {
-    ?locationAnnotation a ext:downloadResource .
     ?rmzAnnotation a ext:downloadResource .
+    ?locationAnnotation a ext:downloadResource .
+    ?locationTarget a ext:downloadResource .
+    ?locationSelector a ext:downloadResource .
     ?location a ext:downloadResource .
     ?geometry a ext:downloadResource .
-    ?selector a ext:downloadResource .
+    ?locationStatement a ext:downloadResource .
     ?dateApplicabilityAnnotation a ext:downloadResource .
+    ?dateApplicabilityStatement a ext:downloadResource .
+    ?dateApplicabilityTarget a ext:downloadResource .
+    ?dateApplicabilitySelector a ext:downloadResource .
     ?normativeProvisionAnnotation a ext:downloadResource .
     ?normativeProvisionStatement a ext:downloadResource .
     ?normativeProvision a ext:downloadResource .
+    ?normativeProvisionTarget a ext:downloadResource .
+    ?normativeProvisionSelector a ext:downloadResource .
     ?impactPeriodAnnotation a ext:downloadResource .
     ?impactPeriodStatement a ext:downloadResource .
     ?impactPeriod a ext:downloadResource .
+    ?impactPeriodTarget a ext:downloadResource .
+    ?impactPeriodSelector a ext:downloadResource .
   }
 }
 where {
@@ -32,37 +41,58 @@ where {
   ?rmzAnnotation oa:hasTarget ?expression .
   ?rmzConcept skos:inScheme <http://data.lblod.gift/id/conceptscheme/restricted-mobility-zone-simple> .
 
-  optional {
-    ?locationAnnotation a oa:Annotation .  
-    ?locationAnnotation oa:hasBody ?location .
-    ?location locn:geometry ?geometry .
+  ?work eli:is_realized_by ?expression .
 
-    ?locationAnnotation oa:hasTarget ?locationTarget .
-    ?locationTarget oa:hasSource ?expression .
-    ?locationTarget oa:hasSelector ?selector .
+  optional {
+    ?locationAnnotation a oa:Annotation ;  
+      oa:hasBody ?locationStatement ;
+      oa:hasTarget ?locationTarget .
+
+    ?locationTarget oa:hasSource ?expression ;
+      oa:hasSelector ?locationSelector .
+
+    ?locationStatement rdf:subject ?work ;
+        rdf:predicate prov:atLocation ;
+        rdf:object ?location .
+    
+    optional {
+      ?location locn:geometry ?geometry .
+    }
   }
 
   optional {
     ?dateApplicabilityAnnotation a oa:Annotation ;
-        oa:hasBody/rdf:predicate eli:date_applicability ;
-        oa:hasTarget ?expression .
+      oa:hasBody ?dateApplicabilityStatement ;
+      oa:hasTarget ?dateApplicabilityTarget .
+      
+    ?dateApplicabilityTarget oa:hasSelector ?dateApplicabilitySelector ;
+      oa:hasSource ?expression .
+
+    ?dateApplicabilityStatement rdf:predicate eli:date_applicability .
   }
 
   optional {
     ?normativeProvisionAnnotation a oa:Annotation ;
         oa:hasBody ?normativeProvisionStatement ;
-        oa:hasTarget ?expression .
+        oa:hasTarget ?normativeProvisionTarget .
+      
+    ?normativeProvisionTarget oa:hasSource ?expression ;
+        oa:hasSelector ?normativeProvisionSelector .
 
-    ?normativeProvisionStatement rdf:predicate eli:realizes ;
+    ?normativeProvisionStatement rdf:subject ?work ;
+         rdf:predicate eli:realizes ;
         rdf:object ?normativeProvision .
     
-    ?normativeProvision a omgeving:NormativeProvision .
+    ?normativeProvision a omgeving:NormatieveBepaling .
   }
 
   optional {
     ?impactPeriodAnnotation a oa:Annotation ;
         oa:hasBody ?impactPeriodStatement ;
-        oa:hasTarget ?expression .
+        oa:hasTarget ?impactPeriodTarget .
+
+    ?impactPeriodTarget oa:hasSource ?expression ;
+        oa:hasSelector ?impactPeriodSelector .
 
     ?impactPeriodStatement rdf:predicate dct:extent ;
         rdf:object ?impactPeriod .    


### PR DESCRIPTION
# Context

The `rmz` dataset should also contain the time aspect of the RMZ, next to its location.
Time is expressed with `eli:date_applicability` (impact date), and `dct:extent` (impact period) that is linked through the Normative provision.
In the end, lots of fixes have been applied to the query: 
- URI of the RMZ (simple) codelist
- geometry is optional (when not linked with OSM)
- selectors, targets also published
- locations are linked through work
- normative provision is linked through work
- date applicability statements can have period URIs as object, so are exported separately

# How to test

Use the following decision that is classified as RMZ:
`2024_CBS_06015 - Inname van het openbaar domein - Mimosastraat - voor de organisatie van een leefstraat vanaf 29/06/2024 t.e.m. 29/09/2024 - Goedkeuring`
Decision URI: `https://data.gent.be/id/besluiten/24.0603.2227.8372`
URL website: `https://ebesluitvorming.gent.be/zittingen/23.1002.8187.4634/agendapunten/24.0603.2227.8372`

### Step 1:
make sure this decision is in your triple store annotated as RMZ (is the case when you use the data from the test server). You can test with following query:
```
prefix skos: <http://www.w3.org/2004/02/skos/core#>
prefix oa: <http://www.w3.org/ns/oa#>

select *
where {
  ?rmzAnnotation oa:hasBody ?rmzConcept .
  ?rmzAnnotation oa:hasTarget ?expression .
  ?rmzConcept skos:inScheme <http://data.lblod.gift/id/conceptscheme/restricted-mobility-zone-simple> .

  VALUES ?expression { <https://data.gent.be/id/besluiten/24.0603.2227.8372> }
}

```
If not, run the codelist (evaluation) pipeline:
- codelist URI: http://data.lblod.gift/id/conceptscheme/restricted-mobility-zone-simple
- decision URI: https://data.gent.be/id/besluiten/24.0603.2227.8372
- decision graph: http://mu.semte.ch/graphs/public/gent

### Step 2:
Run the "Perform NER & Entity linking on ELI decisions & Publish"

You can verify the annotations in the HVT:
`http://human-validator.localhost/validate/fc383e8b-36d6-55ee-a385-b894d6063e87`

<img width="1928" height="908" alt="image" src="https://github.com/user-attachments/assets/c33d1e02-1101-43f8-b30a-852b36373b65" />

Location: Mimosastraat, Gent
Data applicability: there are three wrong annotations (2 period, one with "vanaf")
Impact period: 2 duplicates, one with "vanaf - vanaf"

### Step 3:
Run the `publish dataset` script:
`mu script project-scripts publish-dataset --dataset rmz --org gent`

### Step 4:

Check the generated datadump in the datadumps folder: `./data/datadumps/TIMESTAMP-rmz.ttl`

You should find `date_applicability`:
```
<http://data.lblod.info/id/statements/5dcb7204-fdc1-4869-a459-bffacbd1330f> a rdf:Statement ;
    ns2:uuid "d755ab80-0df6-4f70-89fe-bbd40cbaf73e" ;
    rdf:object <https://data.lblod.info/id/period/6e68ed5a-3e41-4b16-a367-16872da956f2> ;
    rdf:predicate <http://data.europa.eu/eli/ontology#date_applicability> ;
    rdf:subject <https://data.gent.be/id/besluiten/24.0603.2227.8372/work> .
```

`extent`:
```
<http://data.lblod.info/id/statements/c0b99097-5048-49a1-ad9b-cd459e940c45> a rdf:Statement ;
    ns2:uuid "dcabbe55-c374-46e4-93d0-64392cf1f695" ;
    rdf:object <https://data.lblod.info/id/period/20e0eb0e-c4e7-4bc5-a1f0-8ce988421447> ;
    rdf:predicate dcterms:extent ;
    rdf:subject <https://data.lblod.info/id/normatievebepaling/1371dfb2-a76c-4c41-91d7-959e02c1447f> .

<https://data.lblod.info/id/normatievebepaling/1371dfb2-a76c-4c41-91d7-959e02c1447f> a <https://data.vlaanderen.be/ns/omgevingsvergunning#NormatieveBepaling> ;
    ns2:uuid "1371dfb2-a76c-4c41-91d7-959e02c1447f" ;
    dcterms:extent <https://data.lblod.info/id/period/20e0eb0e-c4e7-4bc5-a1f0-8ce988421447> .

<https://data.lblod.info/id/period/20e0eb0e-c4e7-4bc5-a1f0-8ce988421447> a time:ProperInterval ;
    ns2:uuid "20e0eb0e-c4e7-4bc5-a1f0-8ce988421447" ;
    time:hasBeginning "2024-09-29"^^xsd:date ;
    time:hasEnd "2024-09-29"^^xsd:date .
```

`locations` (also the ones not linked with OSM):
```
<http://data.lblod.info/id/statements/a6720ce1-569a-451e-93c3-335a5731a490> a rdf:Statement ;
    ns2:uuid "6b1bf171-8f70-488f-9fab-a6be234dcbdf" ;
    rdf:object <http://data.lblod.info/id/locations/495ba083-ab37-4861-8d8e-687ca2c17855> ;
    rdf:predicate prov:atLocation ;
    rdf:subject <https://data.gent.be/id/besluiten/24.0603.2227.8372/work> .

<http://data.lblod.info/id/locations/495ba083-ab37-4861-8d8e-687ca2c17855> a dcterms:Location ;
    rdfs:label "Mimosastraat, Gent" ;
    ns2:uuid "495ba083-ab37-4861-8d8e-687ca2c17855" .
```

