### PR TITLE
feat: register mistral-medium-3.5 openrouterId for AI cost lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,26 @@ docker compose --profile=search up -d question-answering
 
 See the question-answer service documentation of configuring [LLM providers](https://github.com/semantic-ai/decide-question-answering/blob/master/README.md#L18).
 
+### Registering a new LLM for cost logging
+
+The AI services record their model calls as `ext:AICall` triples, including `ext:cost`. Cost is resolved by looking up the model's `ext:openrouterId` in the triplestore and fetching the rates from OpenRouter. So whenever you point the segmentation or translation service at a different LLM, you must register that model, otherwise `ext:cost` stays `0`.
+
+Add a migration under `config/migrations/` that inserts the model's OpenRouter id:
+
+```sparql
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/harvesting> {
+    <http://data.lblod.info/ontology/airo#MODEL_SLUG>
+        ext:openrouterId "PROVIDER/MODEL_ID" .
+  }
+}
+```
+
+* `MODEL_SLUG` must match the model name after sanitisation: every run of non alphanumeric characters becomes a single `-` and the result is lowercased.
+* `PROVIDER/MODEL_ID` is the exact model id from openrouter.ai, for example `mistralai/mistral-medium-3-5`.
+
 ## Use cases
 
 The DECIDe project is designed to address a set of pre-defined use cases. This README outlines each service individually, allowing cities to select and deploy only the specific components required for their unique needs.

--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -58,7 +58,7 @@ services:
     restart: always
     logging: *default-logging
   pdf-content:
-    image: semanticai/decide-pdf-content-extraction:0.2.0
+    image: semanticai/decide-pdf-content-extraction:0.2.2
     environment:
       APACHE_TIKA_URL: 'http://apache-tika:9998/tika'
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
@@ -129,7 +129,7 @@ services:
     labels:
       - logging=true
   named-entity-recognition:
-    image: semanticai/decide-geocoding-service:0.2.2
+    image: semanticai/decide-geocoding-service:0.2.3
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/20260731105337-register-ai-model-openrouter-ids.sparql
+++ b/config/migrations/20260731105337-register-ai-model-openrouter-ids.sparql
@@ -1,0 +1,8 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/harvesting> {
+    <http://data.lblod.info/ontology/airo#mistral-medium-3-5>
+       ext:openrouterId "mistralai/mistral-medium-3-5" .
+  }
+}


### PR DESCRIPTION
**Summary**

Bumps the pdf-content extraction and geocoding services to the versions that log ext:AICall, registers the model so cost can be computed, and documents how to add future models.


**Changes**

- compose/ai.yml: bump the pdf-content extraction and geocoding service images to the versions with the consolidated ai_logging and AI call cost logging.
- config/migrations/…-register-ai-model-openrouter-ids.sparql: register mistral-medium-3.5 with its ext:openrouterId, so pricing.calculate_cost can resolve rates.
- README.md: new "Registering a new LLM for cost logging" section explaining that switching to a different LLM needs a matching ext:openrouterId migration.


**How to test**

1.  Deploy this version of app-decide
2. On the Harvesting dashboard, launch a new job containing at least the pdf-content extraction or geocoding service.
3. Verify all tasks reach status success, and that ext:AICall records exist with model airo#mistral-medium-3-5:
```PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
PREFIX dct: <http://purl.org/dc/terms/>

SELECT ?call ?model ?tokenIn ?tokenOut ?duration ?cost
WHERE {
  GRAPH ?g {
    ?task dct:isPartOf <JOB_URI> ;
          ext:performedAICall ?call .

    ?call ext:aiModel ?model ;
          ext:tokenIn  ?tokenIn ;
          ext:tokenOut ?tokenOut .

    OPTIONAL { ?call ext:duration ?duration }
    OPTIONAL { ?call ext:cost     ?cost }
  }
}