### PR TITLE
Fix restrictive to restricted mobility zone

### DIFF
--- a/config/migrations/20260731145414-fix-restrictive-mobility-zone-to-restricted.sparql
+++ b/config/migrations/20260731145414-fix-restrictive-mobility-zone-to-restricted.sparql
@@ -1,0 +1,17 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <https://data.vlaanderen.be/id/concept/ZoneType/fc17fa1b-9b61-4396-a609-845643b3b865> skos:prefLabel "Restrictive mobility zone"@en .
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <https://data.vlaanderen.be/id/concept/ZoneType/fc17fa1b-9b61-4396-a609-845643b3b865> skos:prefLabel "Restricted mobility zone"@en .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <https://data.vlaanderen.be/id/concept/ZoneType/fc17fa1b-9b61-4396-a609-845643b3b865> skos:prefLabel "Restrictive mobility zone"@en .
+  }
+}


### PR DESCRIPTION
After migration, label of  `https://data.vlaanderen.be/id/concept/ZoneType/fc17fa1b-9b61-4396-a609-845643b3b865` is "restricted" instead of "restrictive":
<img width="1918" height="478" alt="image" src="https://github.com/user-attachments/assets/ee25e6e8-2812-488b-8885-c285f42ecf6d" />

```
select *
where {
 <https://data.vlaanderen.be/id/concept/ZoneType/fc17fa1b-9b61-4396-a609-845643b3b865> ?p ?o .
}
```