### PR TITLE
fix: remove pdf-scraping split from jobs involving PDF harvesting

### DIFF
--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -58,7 +58,7 @@ services:
     restart: always
     logging: *default-logging
   pdf-content:
-    image: semanticai/decide-pdf-content-extraction:0.2.2
+    image: semanticai/decide-pdf-content-extraction:0.2.3
     environment:
       APACHE_TIKA_URL: 'http://apache-tika:9998/tika'
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting

--- a/config/annotation-job-splitter/config.ts
+++ b/config/annotation-job-splitter/config.ts
@@ -54,18 +54,6 @@ export default {
           },
         ],
       },
-    'http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/pdf-to-eli':
-      {
-        taskConfiguration: [
-          {
-            currentOperation:
-              'http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-eli-scraping',
-            nextOperation:
-              'http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping',
-            harvestingCollection: true,
-          },
-        ],
-      },
     'http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/pdf-to-enriched':
       {
         taskConfiguration: [

--- a/config/annotation-job-splitter/config.ts
+++ b/config/annotation-job-splitter/config.ts
@@ -71,13 +71,6 @@ export default {
         taskConfiguration: [
           {
             currentOperation:
-              'http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-enriched-scraping',
-            nextOperation:
-              'http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping',
-            harvestingCollection: true,
-          },
-          {
-            currentOperation:
               'http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-enriched-translating',
             nextOperation:
               'http://lblod.data.gift/id/jobs/concept/TaskOperation/translating',

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -62,45 +62,39 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-enriched-scraping",
-        "nextIndex": "1"
-      },
-      {
-        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-enriched-scraping",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping",
-        "nextIndex": "2",
-        "external": true
+        "nextIndex": "1"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-to-eli",
-        "nextIndex": "3"
+        "nextIndex": "2"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-to-eli",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-enriched-translating",
-        "nextIndex": "4"
+        "nextIndex": "3"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-enriched-translating",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/translating",
-        "nextIndex": "5",
+        "nextIndex": "4",
         "external": true
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/translating",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/segmenting",
-        "nextIndex": "6"
+        "nextIndex": "5"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/segmenting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
-        "nextIndex": "7"
+        "nextIndex": "6"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/entity-extracting",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/named-entity-linking",
-        "nextIndex": "8"
+        "nextIndex": "7"
       }
     ]
   },

--- a/config/job-controller/config.json
+++ b/config/job-controller/config.json
@@ -37,19 +37,13 @@
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job",
-        "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-eli-scraping",
-        "nextIndex": "1"
-      },
-      {
-        "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/split-task-pdf-to-eli-scraping",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping",
-        "nextIndex": "2",
-        "external": true
+        "nextIndex": "1"
       },
       {
         "currentOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping",
         "nextOperation": "http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-to-eli",
-        "nextIndex": "3"
+        "nextIndex": "2"
       }
     ]
   },


### PR DESCRIPTION
Multiple split tasks in a single job is problematic as the target shape used by the splitter service is linked to the job itself and not the split tasks themselves.  Subsequent split tasks likely require different information in the job's target shape, requiring tasks to update the target shape.  When multiple instances of such tasks run in parallel this leads to unpredictable, and often incorrect, behaviour of the splitter.  By the time a split task is executed, the job's target shape may have been altered from what the split task should be using.

For example, take a `pdf-to-enriched` job for which the user has provided two URLs to harvest PDFs from.  The first split task `split-task-pdf-to-enriched-scraping` would create two `pdf-scraping` tasks, one for each URL.  Subsequently, there will be two `pdf-to-eli` extracting ELI expressions from the PDFs.  Each of these will update the job's target shape such that the second split task `split-task-pdf-to-enriched-translating` can create a `translating` task per extracted expression.  Which shape a `split-task-pdf-to-enriched-translating` retrieves from the triplestore then depends on the order in which the tasks were executed.  For instance, if both `pdf-to-eli` tasks were completed before the `split-task-pdf-to-enriched-translating` tasks, the latter will retrieve the same shape and create follow-up tasks for the same expressions.


## Proposed solution
Limit the number of split tasks to, at most, one per job.  This avoids the need to alter a job's target shape preventing tasks executing in parallel from interfering with each other's changes.

Furthermore, we remove the splitting into multiple `pdf-scraping` tasks altogether.  This allows to keep the harvesting dashboard and pdf-content-extraction service simpler.  Otherwise, they would need to contain logic to determine when to create/update the target shape for a job with PDF harvesting.  More specifically, the dashboard would have to create a shape for `pdf-to-eli` jobs but not for `pdf-to-enriched` jobs. Inversely, the pdf-content service would have to insert as a shape for `pdf-to-enriched` jobs, but not for `pdf-to-eli` jobs.


In the longer term, a more robust solution would be to link target shapes to tasks instead of a job.  For example, by putting it in a task's data container. But this requires more significant changes in the pipeline infrastructure.


## How to test
0. Check out this PR's branch
1. Launch local version for the harvesting dashboard for [#74](https://github.com/lblod/frontend-harvesting-self-service/pull/74)
2. Launch a local version of the pdf-content service for [#36](https://github.com/semantic-ai/decide-pdf-content-extraction/pull/36)
3. Restart the `job-controller` and `annotation-job-splitter` services such that
   they load the modified configurations: `docker compose restart job-controller
   annotation-job-splitter`.
4. Create jobs involving PDF harvesting:
   - "Harvest PDFs from Website URL & Publish as ELI" and "Harvest PDFs from
     Website URL, Publish as ELI and Enrich"
   - Experiment with the number of URLs you provide
5. For "Harvest PDFs from Website URL & Publish as ELI" splits should occur, irrelevant of the number of provided URLs.  For "Harvest PDFs from
     Website URL, Publish as ELI and Enrich" a task split should happen after its `pdf-to-eli` task based on the number of expressions it extracted.


## Related PRs:
- Harvesting dashboard: [#74](https://github.com/lblod/frontend-harvesting-self-service/pull/74)
- PDF content extraction service: [#36](https://github.com/semantic-ai/decide-pdf-content-extraction/pull/36)


## Related tickets
- LBRON-1720