### PR TITLE
chore: bump geocoding service

### DIFF
--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -129,7 +129,7 @@ services:
     labels:
       - logging=true
   named-entity-recognition:
-    image: semanticai/decide-geocoding-service:0.2.3
+    image: semanticai/decide-geocoding-service:0.2.4
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting


### PR DESCRIPTION
**Summary**
Deploys the geocoding fix that makes translation write its ext:AICall (and record cost/model correctly).

**Change**
compose/ai.yml: bump the geocoding (named-entity-recognition) image to the version containing the translation logging fix.

**How to test**

1. docker compose up -d with this bump.
2. Run a pdf-to-enriched job on documents with no existing translation.
3. Confirm each translating task now has an ext:AICall, with ext:aiModel and token counts recorded. ext:cost will be 0 for a local model, or non-zero if you used Mistral's API.
```
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
PREFIX dct: <http://purl.org/dc/terms/>
PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
SELECT ?call ?model ?tokenIn ?tokenOut ?cost WHERE {
  GRAPH ?g {
    ?t dct:isPartOf <JOB_URI> ;
       task:operation <http://lblod.data.gift/id/jobs/concept/TaskOperation/translating> ;
       ext:performedAICall ?call .
    ?call ext:aiModel ?model ; ext:tokenIn ?tokenIn ; ext:tokenOut ?tokenOut .
    OPTIONAL { ?call ext:cost ?cost }
  }
}
```