### PR TITLE
fix(ldes): publish ODRL authorization policy

### DIFF
--- a/config/migrations/20260803144121-fix--add-modified-triple-odrl-authorization-policy.sparql
+++ b/config/migrations/20260803144121-fix--add-modified-triple-odrl-authorization-policy.sparql
@@ -1,0 +1,11 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/odrl-authorization-policy> {
+    ?s dcterms:modified ?now .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/odrl-authorization-policy> {
+    ?s a ?type .
+  }
+  BIND (NOW() AS ?now)
+}


### PR DESCRIPTION
Previously in [#159](https://github.com/lblod/app-decide/pull/159) the `ldes-delta-pusher` was configured to publish the store ODRL authorisation policy to the app's LDES feed.  But because the resources in the policy do not have a `dcterms:modified` triple these resource were not picked up by the healing job.  Consequently, the policy was not actually published to the LDES feed.

This fixes that by inserting a `dcterms:modified` triple for each resource in
the store ODRL authorization policy.


## Proposed solution
Use a migration to insert a `dcterms:modified` triple for every resource in the `http://mu.semte.ch/graphs/odrl-authorization-policy` graph.  This is enough for them to be picked up by the healing job of the `ldes-delta-pusher` service.  A similar approach was taken in [#159](https://github.com/lblod/app-decide/pull/159) for ODRL Offers linked to DCAT datasets.


## How to test
0. Optional, configure the ldes services to serve its feed on localhost:

``` yaml
  ldes-delta-pusher:
    environment:
      LDES_BASE: "http://localhost/ldes/"
  ldes-serve-feed:
    environment:
      BASE_URL: "http://localhost/ldes/"
```

1. Start the app **without** checking out the branch of this PR.
2. Once everything is up and running, confirm that the ODRL authorization policy is missing from the LDES feed.  Either check the feed directly or check the ttl files in `data/ldes-feed/public`[^1].  If your feed is empty, copy the ttl files from, for example, the test server to start from.  Do **not** start the `ldes-delta-pusher` with `WRITE_INITIAL_STATE: "true"`, this will actually add the ODRL authorisation policy data to the feed but is not representative with the situation of our deployed instances of the app.
3. Switch to the branch of this PR.
4. Restart the migrations service: `docker compose restart migrations; docker compose logs -ft --tail=200 migrations`
5. Trigger a manual healing for the `ldes-delta-pusher` service: `docker compose exec ldes-delta-pusher curl -X POST http://localhost/manual-healing`
6. When the healing has finished, check the service logs.  Recheck the (files of the) LDES feed, now it should a version of the store policy.  Likely you will see a bunch of new ttl files in the `data/ldes-feed/public` folder.


[^1]: For example, executing `grep decideAuthorizationPolicy *.ttl` in the folder should **not** return any results.