### PR TITLE
Feat/codelist llm logging

### DIFF
--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -181,7 +181,7 @@ services:
       - ollama serve & pid=$$! && sleep 5 && ollama pull embeddinggemma && wait $$pid
 
   codelist-labeling:
-    image: semanticai/codelist-labeling-service:0.2.0
+    image: semanticai/codelist-labeling-service:0.2.1
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting

--- a/config/codelist/config.json
+++ b/config/codelist/config.json
@@ -1,7 +1,7 @@
 {
   "llm": {
     "provider": "mistralai",
-    "model_name": "mistral-medium-latest",
+    "model_name": "mistral-medium-3.5",
     "temperature": 0.1,
     "base_url": "https://api.mistral.ai/v1",
     "timeout": 120


### PR DESCRIPTION
**Summary**
Deploys AI call cost and duration logging for the codelist labeling service. Bumps the service image to 0.2.1 (which carries the logging code fixes) and points the codelist LLM at mistral-medium-3.5 so logged calls resolve to a priced model.

**Changes**
compose/ai.yml: codelist-labeling image 0.2.0 to 0.2.1
config/codelist/config.json: LLM model_name mistral-medium-latest to mistral-medium-3.5

**How to test**
Deploy the stack on this branch (image 0.2.1) with the openrouterId migration for mistral-medium-3.5 applied.
Run one annotation job over a few decisions you expect to match the codelist, so both annotate and assess-impact fire.
Query the job and confirm every AI call has the real model, a duration, and a non zero cost:
```
PREFIX dct:  <http://purl.org/dc/terms/>
PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
PREFIX ext:  <http://mu.semte.ch/vocabularies/ext/>

SELECT ?op ?model ?dur ?cost WHERE {
  GRAPH ?g {
    ?t dct:isPartOf <JOB_URI> ;
       task:operation ?op ;
       ext:performedAICall ?c .
  }
  GRAPH ?gc {
    ?c ext:aiModel  ?model ;
       ext:duration ?dur ;
       ext:cost     ?cost .
  }
}
ORDER BY ?op
```
Expected: one row per call for both operations, with ?model = airo#mistral-medium-3-5, `?dur` populated, and `?cost` non zero. No row means duration or cost is missing.