### PR TITLE
fix: link legacy annotator components to their current counterparts

### DIFF
--- a/compose/ai.yml
+++ b/compose/ai.yml
@@ -181,7 +181,7 @@ services:
       - ollama serve & pid=$$! && sleep 5 && ollama pull embeddinggemma && wait $$pid
 
   codelist-labeling:
-    image: semanticai/codelist-labeling-service:0.2.1
+    image: semanticai/codelist-labeling-service:0.2.2
     environment:
       TARGET_GRAPH: http://mu.semte.ch/graphs/harvesting
       JOB_GRAPH: http://mu.semte.ch/graphs/harvesting

--- a/config/migrations/20260810101500-map-legacy-components-to-current.sparql
+++ b/config/migrations/20260810101500-map-legacy-components-to-current.sparql
@@ -1,0 +1,16 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.gift/id/components/codelist-annotation/v1.0.0>
+      prov:specializationOf <http://lblod.data.gift/id/components/codelist-labeling/v1.0.0/model_annotator> .
+    <http://lblod.data.gift/id/components/impact-assessment/v1.0.0>
+      prov:specializationOf <http://lblod.data.gift/id/components/codelist-labeling/v1.0.0/impact_annotator> .
+    <http://data.gift/id/components/entity-extraction/v1.0.0>
+      prov:specializationOf <http://lblod.data.gift/id/components/named-entity-recognition/v1.0.0/ner_extractor> .
+    <http://data.gift/id/components/segmentation/v1.0.0>
+      prov:specializationOf <http://lblod.data.gift/id/components/named-entity-recognition/v1.0.0/segmenter> .
+    <http://data.gift/id/components/translation/v1.0.0>
+      prov:specializationOf <http://lblod.data.gift/id/components/named-entity-recognition/v1.0.0/translator> .
+  }
+}


### PR DESCRIPTION
**Summary**
Links the pre-versioning annotator components to the components their services register today, so earlier work is recognised as the same component's output.

**Changes**
config/migrations/20260810101500-map-legacy-components-to-current.sparql: adds a second prov:specializationOf for 
- codelist-annotation → codelist-labeling/v1.0.0/model_annotator
- impact-assessment → codelist-labeling/v1.0.0/impact_annotator
- entity-extraction → named-entity-recognition/v1.0.0/ner_extractor
- segmentation →  named-entity-recognition/v1.0.0/segmenter
- translation →  named-entity-recognition/v1.0.0/translator.

named-entity-linking and pdf-to-eli are excluded: unsuffixed registrations that already land on a live component.

