### PR TITLE
fix incorrect bamberg uri in publish

### DIFF
--- a/scripts/project/publish_dataset/README.md
+++ b/scripts/project/publish_dataset/README.md
@@ -12,11 +12,11 @@ Here is a list of things each partner must do:
     "catalog_uri": "http://data.lblod.info/id/catalogs/7a6b5c4d-3e2f-1a0b-9c8d-7e6f5a4b3c2d",
     "catalog_uuid": "7a6b5c4d-3e2f-1a0b-9c8d-7e6f5a4b3c2d",
     "catalog_publisher": {
-        "uri": "https://opendata.smartcitybamberg.de/decide/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7",
+        "uri": "https://decide.smartcitybamberg.de/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7",
         "name": "City of Bamberg",
         "email": "test@stad.bamberg.de"
     },
-    "organizationFilter": "values ?participant { <https://opendata.smartcitybamberg.de/decide/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7> }",
+    "organizationFilter": "values ?participant { <https://decide.smartcitybamberg.de/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7> }",
     "sparql_endpoint": "https://decide.partner.eu/api/sparql",
     "datadump_base_url": "https://decide.partner.eu/datadumps/"
 }
@@ -102,7 +102,7 @@ Output DCAT is directly written to the triple store in the `PUBLIC_GRAPH` named 
 
 | Organization | URI                                                                                                             |
 | ------------ | --------------------------------------------------------------------------------------------------------------- |
-| Bamberg      | `<https://opendata.smartcitybamberg.de/decide/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7>`              |
+| Bamberg      | `<https://decide.smartcitybamberg.de/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7>`              |
 | Freiburg     | `<https://ris.freiburg.de/oparl/body/FR>`                                                                       |
 | Gent         | `<http://data.lblod.info/id/bestuurseenheden/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5>` |
 | Agency for Local Affairs (ABB)         | `<http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>` |

--- a/scripts/project/publish_dataset/config.json
+++ b/scripts/project/publish_dataset/config.json
@@ -65,10 +65,10 @@
       "catalog_uri": "http://data.lblod.info/id/catalogs/7a6b5c4d-3e2f-1a0b-9c8d-7e6f5a4b3c2d",
       "catalog_uuid": "7a6b5c4d-3e2f-1a0b-9c8d-7e6f5a4b3c2d",
       "catalog_publisher": {
-        "uri": "https://opendata.smartcitybamberg.de/decide/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7",
+        "uri": "https://decide.smartcitybamberg.de/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7",
         "name": "City of Bamberg"
       },
-      "organizationFilter": "values ?organization { <https://opendata.smartcitybamberg.de/decide/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7> }"
+      "organizationFilter": "values ?organization { <https://decide.smartcitybamberg.de/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7> }"
     },
     "gent": {
       "catalog_uri": "http://data.lblod.info/id/catalogs/80fb699a-0d95-4089-843d-79c89138cdb7",

--- a/scripts/project/publish_dataset/config.json
+++ b/scripts/project/publish_dataset/config.json
@@ -68,7 +68,9 @@
         "uri": "https://decide.smartcitybamberg.de/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7",
         "name": "City of Bamberg"
       },
-      "organizationFilter": "values ?organization { <https://decide.smartcitybamberg.de/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7> }"
+      "organizationFilter": "values ?organization { <https://decide.smartcitybamberg.de/organizations#c8e6b8ef-0a33-425a-b9d5-96354823f6e7> }",
+      "datadump_base_url": "https://ds.decide.smartcitybamberg.de/datadumps/",
+      "sparql_endpoint": "http://ds.decide.smartcitybamberg.de/api/sparql"
     },
     "gent": {
       "catalog_uri": "http://data.lblod.info/id/catalogs/80fb699a-0d95-4089-843d-79c89138cdb7",


### PR DESCRIPTION
bamberg used an old uri in its publishing config, resulting in incorrect dcat instances being created without content.

Also added the datadump and sparql urls

## how to test
Run ` mu script project-scripts publish-dataset --dataset human-validations --org bamberg` multiple times, see it create the correct dcat instances with the right download url and with content in its ttl file