### PR TITLE
Export AI calls properties to CSV file

### DIFF
--- a/scripts/project/export_csv/README.md
+++ b/scripts/project/export_csv/README.md
@@ -1,6 +1,6 @@
 # Generic SPARQL-to-CSV export
 
-This mu script runs a configured SPARQL SELECT query and writes its result set to a CSV file. Any dataset can be added by registering a `.sparql` file in `config.json` — nothing about the script itself is tied to a specific dataset. It's currently configured with four datasets that export human validation review results (approve/reject counts) for different annotation types, but new datasets need no code changes, only a new `config.json` entry (see "Adding a new dataset" below).
+This mu script runs a configured SPARQL SELECT query and writes its result set to a CSV file. Any dataset can be added by registering a `.sparql` file in `config.json` — nothing about the script itself is tied to a specific dataset. It's currently configured with datasets exporting human validation review results (approve/reject counts) for different annotation types, and an AI call log, but new datasets need no code changes, only a new `config.json` entry (see "Adding a new dataset" below).
 
 Unlike `publish_dataset`, exports here are not published as open data — no DCAT, no per-organization split.
 
@@ -18,6 +18,7 @@ mu script project-scripts export-csv --dataset codelist-labeling-validations
 mu script project-scripts export-csv --dataset entity-linking-validations
 mu script project-scripts export-csv --dataset smart-search-question-validations
 mu script project-scripts export-csv --dataset smart-search-quotation-validations
+mu script project-scripts export-csv --dataset ai-calls
 ```
 
 Output `.csv` files are written to `OUTPUT_DIR` (`/data/app/data/csv-exports` by default). `scripts/project/config.json` mounts the repo root (`$PWD` where `mu` is invoked) at `/data/app/` for this script, so this lands in `./data/csv-exports` on the host.
@@ -30,8 +31,9 @@ Output `.csv` files are written to `OUTPUT_DIR` (`/data/app/data/csv-exports` by
 | `entity-linking-validations`          | Entity linking human validation results            | yes       |
 | `smart-search-question-validations`   | Smart search question human validation summary     | no        |
 | `smart-search-quotation-validations`  | Smart search quotation human validation summary    | no        |
+| `ai-calls`                            | AI call log (operation, model, tokens, cost, timing) | yes     |
 
-The two row-level datasets can return a large number of rows, so they're fetched in batches (see below). The two summary datasets return a single aggregate row and are run once.
+The row-level datasets can return a large number of rows, so they're fetched in batches (see below). The two summary datasets return a single aggregate row and are run once.
 
 ## Batching
 

--- a/scripts/project/export_csv/config.json
+++ b/scripts/project/export_csv/config.json
@@ -23,6 +23,12 @@
             "sparql_file": "./queries/smart-search-quotation-validations.sparql",
             "output_file_name": "smart-search-quotation-validations",
             "paginated": false
+        },
+        "ai-calls": {
+            "description": "AI call log (operation, model, tokens, cost, timing)",
+            "sparql_file": "./queries/ai-calls.sparql",
+            "output_file_name": "ai-calls",
+            "paginated": true
         }
     }
 }

--- a/scripts/project/export_csv/export_csv.py
+++ b/scripts/project/export_csv/export_csv.py
@@ -69,7 +69,7 @@ def run_export(dataset: str, dataset_config: dict, timestamp: str) -> None:
                     paginate(dataset_config["query"], BATCH_SIZE, offset)
                 )
                 if writer is None:
-                    writer = csv.DictWriter(fh, fieldnames=variables)
+                    writer = csv.DictWriter(fh, fieldnames=variables, delimiter=";")
                     writer.writeheader()
                 for row in rows:
                     writer.writerow(row)
@@ -81,7 +81,7 @@ def run_export(dataset: str, dataset_config: dict, timestamp: str) -> None:
                 offset += BATCH_SIZE
         else:
             variables, rows = select_rows_with_vars(dataset_config["query"])
-            writer = csv.DictWriter(fh, fieldnames=variables)
+            writer = csv.DictWriter(fh, fieldnames=variables, delimiter=";")
             writer.writeheader()
             for row in rows:
                 writer.writerow(row)

--- a/scripts/project/export_csv/queries/ai-calls.sparql
+++ b/scripts/project/export_csv/queries/ai-calls.sparql
@@ -3,7 +3,7 @@ PREFIX ext:  <http://mu.semte.ch/vocabularies/ext/>
 PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
 PREFIX dct:  <http://purl.org/dc/terms/>
 
-SELECT ?call ?operation ?endpoint ?model ?durationSeconds ?costDollar ?tokenIn ?tokenOut ?started ?ended ?codelist
+SELECT ?call ?operation ?endpoint ?model ?codelist ?durationSeconds ?costDollar ?tokenIn ?tokenOut ?started ?ended
 WHERE {
   ?task task:operation ?operation ;
         ext:performedAICall ?call .

--- a/scripts/project/export_csv/queries/ai-calls.sparql
+++ b/scripts/project/export_csv/queries/ai-calls.sparql
@@ -2,7 +2,7 @@ PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
 PREFIX ext:  <http://mu.semte.ch/vocabularies/ext/>
 PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
 
-SELECT ?call ?operation ?endpoint ?model ?duration ?cost ?tokenIn ?tokenOut ?started ?ended
+SELECT ?call ?operation ?endpoint ?model ?durationSeconds ?costDollar ?tokenIn ?tokenOut ?started ?ended
 WHERE {
   ?task task:operation ?operation ;
         ext:performedAICall ?call .
@@ -12,8 +12,8 @@ WHERE {
         ext:tokenIn ?tokenIn ;
         ext:tokenOut ?tokenOut .
 
-  OPTIONAL { ?call ext:duration ?duration . }
-  OPTIONAL { ?call ext:cost ?cost . }
+  OPTIONAL { ?call ext:duration ?durationSeconds . }
+  OPTIONAL { ?call ext:cost ?costDollar . }
   OPTIONAL { ?task ext:startedAt ?started . }
   OPTIONAL { ?task ext:endedAt ?ended . }
 }

--- a/scripts/project/export_csv/queries/ai-calls.sparql
+++ b/scripts/project/export_csv/queries/ai-calls.sparql
@@ -1,0 +1,19 @@
+PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+PREFIX ext:  <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
+
+SELECT ?call ?operation ?endpoint ?model ?duration ?cost ?tokenIn ?tokenOut ?started ?ended
+WHERE {
+  ?task task:operation ?operation ;
+        ext:performedAICall ?call .
+
+  ?call ext:aiModel ?model ;
+        ext:endpoint ?endpoint ;
+        ext:tokenIn ?tokenIn ;
+        ext:tokenOut ?tokenOut .
+
+  OPTIONAL { ?call ext:duration ?duration . }
+  OPTIONAL { ?call ext:cost ?cost . }
+  OPTIONAL { ?task ext:startedAt ?started . }
+  OPTIONAL { ?task ext:endedAt ?ended . }
+}

--- a/scripts/project/export_csv/queries/ai-calls.sparql
+++ b/scripts/project/export_csv/queries/ai-calls.sparql
@@ -1,8 +1,9 @@
 PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
 PREFIX ext:  <http://mu.semte.ch/vocabularies/ext/>
 PREFIX mu:   <http://mu.semte.ch/vocabularies/core/>
+PREFIX dct:  <http://purl.org/dc/terms/>
 
-SELECT ?call ?operation ?endpoint ?model ?durationSeconds ?costDollar ?tokenIn ?tokenOut ?started ?ended
+SELECT ?call ?operation ?endpoint ?model ?durationSeconds ?costDollar ?tokenIn ?tokenOut ?started ?ended ?codelist
 WHERE {
   ?task task:operation ?operation ;
         ext:performedAICall ?call .
@@ -16,4 +17,9 @@ WHERE {
   OPTIONAL { ?call ext:cost ?costDollar . }
   OPTIONAL { ?task ext:startedAt ?started . }
   OPTIONAL { ?task ext:endedAt ?ended . }
+
+  OPTIONAL {
+    ?task dct:isPartOf ?job .
+    ?job ext:codelist ?codelist .
+  }
 }


### PR DESCRIPTION
In order to get insights into cost, duration etc of AI calls, a CSV file is generated. This results are non-aggregated by design in order for PMs to aggregate and pivot the resulting data themselves.

A mu script helps generate the CSV file, it can be triggered as follows:

````bash
mu script project-scripts export-csv --dataset ai-calls
```

By default, the CSV file is exported to the `data/csv-exports/` folder