### PR TITLE
chore: update stored authorisation policy

### DIFF
--- a/config/migrations/insert-odrl-authorization-policy/20260811140825-updated-authorisation-policy.graph
+++ b/config/migrations/insert-odrl-authorization-policy/20260811140825-updated-authorisation-policy.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/odrl-authorization-policy

--- a/config/migrations/insert-odrl-authorization-policy/20260811140825-updated-authorisation-policy.ttl
+++ b/config/migrations/insert-odrl-authorization-policy/20260811140825-updated-authorisation-policy.ttl
@@ -1,0 +1,728 @@
+# For more details in writing authorisation policies in ODRL, see
+# sparql-parser's README.
+# <https://github.com/mu-semtech/sparql-parser/tree/feature/odrl-configuration?tab=readme-ov-file#defining-an-authorization-policy-in-odrl>
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix besluit: <http://data.vlaanderen.be/ns/besluit#> .
+@prefix cms: <http://mu.semte.ch/vocabulary/cms/> .
+@prefix cogs: <http://vocab.deri.ie/cogs#> .
+@prefix core: <http://open-services.net/ns/core#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix defend: <https://d3fend.mitre.org/ontologies/d3fend#> .
+@prefix eli: <http://data.europa.eu/eli/ontology#> .
+@prefix eli-dl: <http://data.europa.eu/eli/eli-draft-legislation-ontology#> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+@prefix harvesting: <http://lblod.data.gift/vocabularies/harvesting/> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#> .
+@prefix ndo: <http://oscaf.sourceforge.net/ndo.html#> .
+@prefix nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix oparl-temp: <http://mu.semte.ch/vocabularies/ext/oparl/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix perceel: <https://data.vlaanderen.be/ns/perceel#> .
+@prefix person: <http://www.w3.org/ns/person#> .
+@prefix schema: <http://schema.org/> .
+@prefix security: <http://lblod.data.gift/vocabularies/security/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix tasks: <http://redpencil.data.gift/vocabularies/tasks/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix wikidata: <http://www.wikidata.org/entity/> .
+@prefix wot: <https://www.w3.org/2019/wot/security#> .
+@prefix session: <http://mu.semte.ch/vocabularies/session/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+ext:muAuthProfile a odrl:Profile ;
+  dct:description "ODRL profile describing access to mu-auth resources." .
+
+ext:decideAuthorizationPolicy a odrl:Set ;
+  odrl:profile ext:muAuthProfile ;
+  odrl:permission ext:allowReadForPublic ,
+    ext:allowReadForOrganizations ,
+    ext:allowReadForHarvestedFreiburg ,
+    ext:allowReadForHarvestedGent ,
+    ext:allowReadForHarvestedPdf ,
+    ext:allowReadForHarvestingPublic ,
+    ext:allowReadForHarvesting ,
+    ext:allowWriteForHarvesting ,
+    ext:allowReadForOrganization ,
+    ext:allowReadForOsloOrganizations ,
+    ext:allowReadForAiSlice ,
+    ext:allowReadOsloOrgsForHumanValidation ,
+    ext:allowReadForHumanValidation ,
+    ext:allowQuestionAnsweringReadForHumanValidation,
+    ext:allowReadHarvestingForHumanValidation ,
+    ext:allowWriteForHumanValidation ,
+    ext:allowReadForQuestionAnswering ,
+    ext:allowWriteForQuestionAnswering ,
+    ext:allowReadOsloOrgsForQuestionAnswering,
+    ext:allowReadPublicForQuestionAnswering,
+    ext:allowReadGhentForQuestionAnswering,
+    ext:allowReadFreiburgForQuestionAnswering,
+    ext:allowReadPdfForQuestionAnswering,
+    ext:allowReadAiSliceForQuestionAnswering,
+    ext:allowReadAnnotationForPublic ,
+    ext:allowReadAnnotationForGhent ,
+    ext:allowReadAnnotationForFreiburg ,
+    ext:allowReadAnnotationForPdf ,
+    ext:allowAnnotationReadForAiSlice ,
+    ext:allowReadForSession ,
+    ext:allowWriteForSession ,
+    ext:allowReadPublicForSession ,
+    ext:allowReadOrgsForSession ,
+    ext:allowPublicReadForAuthz .
+
+# Parties for groups
+ext:decideSystem a odrl:Party ;
+  vcard:fn "DECIDe System" ;
+  dct:description "The DECIDe system party used as an assigner of the permissions in this policy." .
+
+ext:publicParty a odrl:PartyCollection ;
+  vcard:fn "public" ;
+  dct:description "This party represent all (possibly not logged in) users of the system." .
+
+ext:sessionService a odrl:PartyCollection ;
+  vcard:fn "session service" ;
+  dct:description "This party represent all session services running in the system." .
+
+# NOTE (19/06/2026): The filter excludes sessions associated with a mock-login
+# account.  This avoids that users using the yasgui/VC frontend can write to the
+# harvesting graph as their sessions are always linked to the mock-login
+# account.  This exclusion has two important drawbacks:
+# - If sessions for users authenticated via VC are in the future linked to
+#   non-mock-login accounts this filter will no longer work.
+# - If other types of authenticated users are added to the app, they will still
+#   be automatically members of this party and be granted the corresponding
+#   rights.
+#
+# If either of these two scenarios occur a better solution must be applied.
+# Since we do not expect them to occur within the scope of the DECIDe project
+# this solution is satisfactory.
+ext:authenticatedParty a odrl:PartyCollection ;
+  vcard:fn "logged-in" ;
+  ext:definedBy """PREFIX session: <http://mu.semte.ch/vocabularies/session/>
+  PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+  SELECT DISTINCT ?account
+  WHERE {
+    <SESSION_ID> session:account ?account .
+    FILTER NOT EXISTS {
+      ?account foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service> .
+    }
+  }""" ;
+  dct:description "This represents all logged in users of the system." .
+
+ext:organizationMemberParty a odrl:PartyCollection ;
+  vcard:fn "organization-member" ;
+  ext:queryParameters "session_group" ;
+  ext:definedBy """PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+          PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+          SELECT ?session_group ?session_role WHERE {
+            <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group.
+          }""" .
+
+# Asset collections for graphs
+ext:decideHarvestingSlice a odrl:AssetCollection ;
+  vcard:fn "harvesting" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/harvesting> ;
+  dct:description "This asset collection contains all information that is available in as part the harvesting done by the DECIDE app." .
+
+# NOTE (24/03/2026): plural organizationS
+ext:decideOrganizationsSlice a odrl:AssetCollection ;
+  vcard:fn "organizations" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/organizations> .
+
+# NOTE (24/03/2026): singular organization
+ext:decideOrganizationSlice a odrl:AssetCollection ;
+  vcard:fn "organization" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/organizations/> .
+
+# NOTE (10/02/2026): Graph <http://mu.semte.ch/graphs/organizations> does NOT
+# contain the `besluit:Bestuurseenheid` type (only `org:Organization`), using
+# that graph causes resource service to bug out for acm/idm login.
+ext:decideOsloOrganizationsSlice a odrl:AssetCollection ;
+  vcard:fn "oslo-organizations" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/bestuurseenheden-bestuursorganen> .
+
+ext:decideHarvestedFreiburgSlice a odrl:AssetCollection ;
+  vcard:fn "harvested-freiburg" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/public/freiburg> .
+
+ext:decideHarvestedGentSlice a odrl:AssetCollection ;
+  vcard:fn "harvested-gent" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/public/gent> .
+
+ext:decideHarvestedPdfSlice a odrl:AssetCollection ;
+  vcard:fn "harvested-pdf" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/public/pdf> .
+
+ext:decidePublicSlice a odrl:AssetCollection ;
+  vcard:fn "public" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/public> ;
+  dct:description "This asset collection contains all information that is available to the public in the context of the DECIDe app." .
+
+ext:decideHumanValidationSlice a odrl:AssetCollection ;
+  vcard:fn "human-validation" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/public/human-validation> .
+
+ext:decideQuestionAnsweringSlice a odrl:AssetCollection ;
+  vcard:fn "question-answering" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/public/question-answering> .
+
+ext:decideSessionSlice a odrl:AssetCollection ;
+  vcard:fn "session information" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/sessions> .
+
+ext:decideAiSlice a odrl:AssetCollection ;
+  vcard:fn "ai" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/ai> .
+
+# Permissions for grants
+ext:allowReadForPublic a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decidePublicSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForOrganizations a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideOrganizationsSlice ; # NOTE (24/03/2026): plural organizationS
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForHarvestedFreiburg a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedFreiburgSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForHarvestedGent a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedGentSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForHarvestedPdf a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedPdfSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForHarvesting a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestingSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:authenticatedParty .
+
+ext:allowReadForHarvestingPublic a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestingSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowWriteForHarvesting a odrl:Permission ;
+  odrl:action odrl:modify ;
+  odrl:target ext:decideHarvestingSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:authenticatedParty .
+
+ext:allowReadForOrganization a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideOrganizationSlice ; # NOTE (24/03/2026): Singular organization
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:organizationMemberParty .
+
+ext:allowReadForOsloOrganizations a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideOsloOrganizationsSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForAiSlice a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideAiSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .
+
+ext:allowReadForSession a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideSessionSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/sessions" .
+
+ext:allowWriteForSession a odrl:Permission ;
+  odrl:action odrl:modify ;
+  odrl:target ext:decideSessionSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/sessions" .
+
+ext:allowReadPublicForSession a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decidePublicSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/sessions" .
+
+ext:allowReadOrgsForSession a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideOsloOrganizationsSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/sessions" .
+
+ext:allowReadForHumanValidation a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHumanValidationSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadHarvestingForHumanValidation a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestingSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowQuestionAnsweringReadForHumanValidation a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideQuestionAnsweringSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowWriteForHumanValidation a odrl:Permission ;
+  odrl:action odrl:modify ;
+  odrl:target ext:decideHumanValidationSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadForQuestionAnswering a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideQuestionAnsweringSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/decide-question-answering-service" .
+
+ext:allowWriteForQuestionAnswering a odrl:Permission ;
+  odrl:action odrl:modify ;
+  odrl:target ext:decideQuestionAnsweringSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/decide-question-answering-service" .
+
+ext:allowReadOsloOrgsForHumanValidation a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideOsloOrganizationsSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadAnnotationForPublic a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decidePublicSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadAnnotationForGhent a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedGentSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadAnnotationForFreiburg a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedFreiburgSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadAnnotationForPdf a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedPdfSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowAnnotationReadForAiSlice a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideAiSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/annotation-review-service" .
+
+ext:allowReadOsloOrgsForQuestionAnswering a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideOsloOrganizationsSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty  ;
+  ext:scope "http://services.semantic.works/decide-question-answering-service" .
+
+ext:allowReadPublicForQuestionAnswering a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decidePublicSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/decide-question-answering-service" .
+
+ext:allowReadGhentForQuestionAnswering a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedGentSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/decide-question-answering-service" .
+
+ext:allowReadFreiburgForQuestionAnswering a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedFreiburgSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/decide-question-answering-service" .
+
+ext:allowReadPdfForQuestionAnswering a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideHarvestedPdfSlice ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/decide-question-answering-service" .
+
+ext:allowReadAiSliceForQuestionAnswering a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideAiSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty ;
+  ext:scope "http://services.semantic.works/decide-question-answering-service" .
+
+# Assets (SHACL shapes) for type specifications
+ext:BesluitAdministrativeUnitAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideOsloOrganizationsSlice;
+  sh:targetClass besluit:Bestuurseenheid .
+
+ext:CmsPageAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass cms:Page .
+
+ext:DcatCatalogAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingSlice ;
+  sh:targetClass dcat:Catalog .
+
+ext:DcatDatasetAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingSlice ;
+  sh:targetClass dcat:Dataset .
+
+ext:DcatDistributionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingSlice ;
+  sh:targetClass dcat:Distribution .
+
+ext:DctMediaTypeOrExtentAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass dct:MediaTypeOrExtent .
+
+ext:DctPeriodOfTimeAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass dct:PeriodOfTime .
+
+ext:ElidlActivityAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingPublicSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass eli-dl:Activity .
+
+ext:ElidlDecisionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:Decision .
+
+ext:ElidlDraftLegislationWorkAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:DraftLegislationWork .
+
+ext:ElidlForeseenActivityAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:ForeseenActivity .
+
+ext:ElidlLegislativeProcessAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:LegislativeProcess .
+
+ext:ElidlLegislativeProcessWorkAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:LegislativeProcessWork .
+
+ext:ElidlParliamentaryTermAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:ParliamentaryTerm .
+
+ext:ElidlParticipationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:Participation .
+
+ext:ElidlProcessStageAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:ProcessStage .
+
+ext:ElidlVoteAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli-dl:Vote .
+
+ext:EliComplexWorkAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass eli:ComplexWork .
+
+ext:EliExpressionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingPublicSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass eli:Expression .
+
+ext:EliLegalExpressionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingPublicSlice ;
+  sh:targetClass eli:LegalExpression .
+
+ext:EliManifestationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestingPublicSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass eli:Manifestation .
+
+ext:EliWorkAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass eli:Work .
+
+ext:FoafAgentAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass foaf:Agent .
+
+ext:FoafPersonAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideOrganizationSlice ;
+  sh:targetClass foaf:Person .
+
+ext:FoafOnlineAccountAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideOrganizationSlice ;
+  sh:targetClass foaf:OnlineAccount .
+
+ext:AdmsIdentifierAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideOrganizationSlice ;
+  sh:targetClass adms:Identifier .
+
+ext:OparltempLocationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass oparl-temp:Location .
+
+ext:OrgMembershipAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass org:Membership .
+
+ext:OrgOrganizationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideOrganizationsSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass org:Organization .
+
+ext:SkosConceptAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass skos:Concept .
+
+ext:SkosConceptSchemeAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass skos:ConceptScheme .
+
+ext:DctLocationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass dct:Location .
+
+ext:LocnGeometryAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass locn:Geometry .
+
+ext:LocnAddressAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass locn:Address .
+
+ext:SchemaTouristAttractionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass schema:TouristAttraction .
+
+ext:PerceelPerceelAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass perceel:Perceel .
+
+ext:WikidataQ2785216Asset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass wikidata:Q2785216 .
+
+ext:OaAnnotationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideAiSlice ;
+  sh:targetClass oa:Annotation .
+
+ext:OaSpecificResourceAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideAiSlice ;
+  sh:targetClass oa:SpecificResource .
+
+ext:OaTextPositionSelectorAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ,
+    ext:decideAiSlice ;
+  sh:targetClass oa:TextPositionSelector .
+
+ext:SessionAsset a odrl:Asset, sh:NodeSchape ;
+  odrl:partOf ext:decideSessionSlice ;
+  sh:targetClass session:Session .
+
+ext:TasksTaskAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass tasks:Task .
+
+ext:TasksScheduledTaskAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass tasks:ScheduledTask .
+
+ext:TasksCronScheduleAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass tasks:CronSchedule .
+
+ext:CogsJobAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass cogs:Job .
+
+ext:ExtAnnotionJobAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decidePublicSlice ;
+  sh:targetClass ext:AnnotationJob .
+
+ext:ExtReviewAnnotationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHumanValidationSlice ;
+  sh:targetClass ext:ReviewAnnotation .
+
+ext:ExtAnnotationTargetAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHumanValidationSlice ;
+  sh:targetClass ext:AnnotationTarget .
+
+ext:ExtCorrectionAnnotationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHumanValidationSlice ;
+  sh:targetClass ext:CorrectionAnnotation .
+
+ext:ActivityAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHumanValidationSlice ;
+  sh:targetClass prov:Activity .
+
+ext:StatementAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHumanValidationSlice ;
+  sh:targetClass rdf:Statement .
+
+ext:SchemaQuestionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideQuestionAnsweringSlice ,
+    ext:decideAiSlice ;
+  sh:targetClass schema:Question .
+
+ext:SchemaAnswerAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideQuestionAnsweringSlice ,
+    ext:decideAiSlice ;
+  sh:targetClass schema:Answer .
+
+ext:SchemaQuotationAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideQuestionAnsweringSlice ,
+    ext:decideAiSlice ;
+  sh:targetClass schema:Quotation .
+
+ext:NodeShapeAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decideAuthzSlice ;
+  sh:targetClass sh:NodeShape .
+
+ext:CogsScheduledJobAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass cogs:ScheduledJob .
+
+ext:SchemaRepeatFrequencyAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass schema:repeatFrequency .
+
+ext:CoreErrorAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass core:Error .
+
+ext:HarvestingHarvestingCollectionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass harvesting:HarvestingCollection .
+
+ext:NfoRemoteDataObjectAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decideHarvestingPublicSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass nfo:RemoteDataObject .
+
+ext:NfoFileDataObjectAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decideHarvestingPublicSlice ,
+    ext:decideHarvestedFreiburgSlice ,
+    ext:decideHarvestedGentSlice ,
+    ext:decideHarvestedPdfSlice ;
+  sh:targetClass nfo:FileDataObject .
+
+ext:NfoDataContainerAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ,
+    ext:decidePublicSlice ;
+  sh:targetClass nfo:DataContainer .
+
+ext:NdoDownloadEventAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideHarvestingSlice ;
+  sh:targetClass ndo:DownloadEvent .
+
+# Access rights to the stored copy of this policy itself
+ext:decideAuthzSlice a odrl:AssetCollection ;
+  vcard:fn "odrl-authorization-policy" ;
+  ext:graphPrefix <http://mu.semte.ch/graphs/odrl-authorization-policy> .
+
+ext:OdrlProfileAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:Profile .
+
+ext:OdrlPartyAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:Party .
+
+ext:OdrlPartyCollectionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:PartyCollection .
+
+ext:OdrlAssetCollectionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:AssetCollection .
+
+ext:OdrlAssetAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:Asset .
+
+ext:OdrlPermissionAsset a odrl:Asset, sh:NodeShape ;
+  odrl:partOf ext:decideAuthzSlice ;
+  sh:targetClass odrl:Permission .
+
+ext:allowPublicReadForAuthz a odrl:Permission ;
+  odrl:action odrl:read ;
+  odrl:target ext:decideAuthzSlice ;
+  odrl:assigner ext:decideSystem ;
+  odrl:assignee ext:publicParty .

--- a/config/migrations/insert-odrl-authorization-policy/20260812061548-insert-modified-timestamps.sparql
+++ b/config/migrations/insert-odrl-authorization-policy/20260812061548-insert-modified-timestamps.sparql
@@ -1,0 +1,11 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/odrl-authorization-policy> {
+    ?s dcterms:modified ?now .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/odrl-authorization-policy> {
+    ?s a ?type .
+  }
+  BIND (NOW() AS ?now)
+}


### PR DESCRIPTION
Update the stored authorisation policy so it is back up to date with the one actually used the `sparql-parser` service.  Furthermore, add timestamps of the modification so the update is picked up by the healing functionality of the `ldes-delta-pusher.


## Approach
The full ODRL authorisation configuration is re-inserted as a ttl migration into the same graph.  This will effectively result in only the new triples being inserted.

Afterwards, the second migration inserts a `dcterms:modified` triple for each typed resource in the graph.


## How to test
0. Check out this PR's branch
1. Restart the migrations service: `docker compose restart migrations`
2. Check the `<http://mu.semte.ch/graphs/odrl-authorization-policy>` graph to see it contains the recently added elements. (See, for example, [#160](https://github.com/lblod/app-decide/pull/160) or [#127](https://github.com/lblod/app-decide/pull/127).)
3. Check whether all resources have a `dcterms:modified` triple with as object a timestamp matching the time you did step 1.
4. Trigger a manual healing for the `ldes-delta-pusher` service: `docker compose exec ldes-delta-pusher curl -X POST http://localhost/manual-healing`
5. When the healing has finished, keep an eye on the service logs, check the (files of the) LDES feed.  It should contain the versioned versions of the new elements as well as the timestamp triples.


If you want to inspect the LDES feed directly be sure to set localhost as base URL:

``` yaml
  # docker-compose.override.yml
  ldes-delta-pusher:
    environment:
      LDES_BASE: "http://localhost/ldes/"
  ldes-serve-feed:
    environment:
      BASE_URL: "http://localhost/ldes/"
```

## Related tickets
- LBRON-1766