### PR TITLE
DO NOT MERGE - local migration for adding the Vlaamse Codex to our dcat

### DIFF
--- a/config/migrations/20260812103000-add-vlaamse-codex-to-dcat.sparql
+++ b/config/migrations/20260812103000-add-vlaamse-codex-to-dcat.sparql
@@ -15,36 +15,25 @@ INSERT DATA {
 ;
 INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
-    <http://data.lblod.info/id/services/a5d0d3ff-1593-4861-9cdc-f65d358ffa36> a dcat:DataService;
-      mu:uuid "a5d0d3ff-1593-4861-9cdc-f65d358ffa36";
-      dct:title "Vlaamse Codex"@nl;
-      dcat:endpointURL <https://codex.vlaanderen.be>;
-      dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
-      dcat:servesDataset <http://data.lblod.info/id/datasets/1f898ab4-1008-4701-99ed-bafa494a6910> .
-  }
-}
-;
-INSERT DATA {
-  GRAPH <http://mu.semte.ch/graphs/public> {
     <http://data.lblod.info/id/distributions/bfe864fa-4eb6-477c-9f0e-1846b5c315cb> a dcat:Distribution;
       mu:uuid "bfe864fa-4eb6-477c-9f0e-1846b5c315cb";
       dct:title "SPARQL Endpoint"@nl;
-      dct:issued "2026-08-12T00:00:00"^^xsd:dateTime;
-      dct:modified "2026-08-12T00:00:00"^^xsd:dateTime;
       dcat:accessURL <https://codex.opendata.api.vlaanderen.be:8888/sparql>;
       dcat:accessService <http://data.lblod.info/id/services/a5d0d3ff-1593-4861-9cdc-f65d358ffa36>;
       dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
-      dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> .
+      dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+      dct:issued "2026-08-12T00:00:00"^^xsd:dateTime;
+      dct:modified "2026-08-12T00:00:00"^^xsd:dateTime.
 
-    <http://data.lblod.info/id/distributions/95973b1c-4275-4902-8d34-376a593326a6>
-      a dcat:Distribution;
+    <http://data.lblod.info/id/distributions/95973b1c-4275-4902-8d34-376a593326a6> a dcat:Distribution;
       mu:uuid "95973b1c-4275-4902-8d34-376a593326a6";
       dct:title "JSON-LD API"@nl;
-      dct:issued "2026-08-12T00:00:00"^^xsd:dateTime;
-      dct:modified "2026-08-12T00:00:00"^^xsd:dateTime;
       dcat:accessURL <https://codex.opendata.api.vlaanderen.be:443/api>;
+      dcat:accessService <http://data.lblod.info/id/services/0b18c1de-c1db-4de5-a2ad-6fd29434509e>;
       dct:format <http://publications.europa.eu/resource/authority/file-type/JSON_LD>;
-      dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> .
+      dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+      dct:issued "2026-08-12T00:00:00"^^xsd:dateTime;
+      dct:modified "2026-08-12T00:00:00"^^xsd:dateTime.
   }
 }
 ;
@@ -63,7 +52,25 @@ INSERT DATA {
       dct:issued "2026-08-12T00:00:00"^^xsd:dateTime;
       dct:modified "2026-08-12T00:00:00"^^xsd:dateTime;
       dcat:distribution
-          <http://data.lblod.info/id/distributions/bfe864fa-4eb6-477c-9f0e-1846b5c315cb>,
-          <http://data.lblod.info/id/distributions/95973b1c-4275-4902-8d34-376a593326a6> .
+        <http://data.lblod.info/id/distributions/bfe864fa-4eb6-477c-9f0e-1846b5c315cb>,
+        <http://data.lblod.info/id/distributions/95973b1c-4275-4902-8d34-376a593326a6> .
+  }
+}
+;
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/services/a5d0d3ff-1593-4861-9cdc-f65d358ffa36> a dcat:DataService;
+      mu:uuid "a5d0d3ff-1593-4861-9cdc-f65d358ffa36";
+      dct:title "Vlaamse Codex SPARQL Endpoint"@nl;
+      dcat:endpointURL <https://codex.opendata.api.vlaanderen.be:8888/sparql>;
+      dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/>;
+      dcat:servesDataset <http://data.lblod.info/id/datasets/1f898ab4-1008-4701-99ed-bafa494a6910> .
+
+    <http://data.lblod.info/id/services/0b18c1de-c1db-4de5-a2ad-6fd29434509e> a dcat:DataService;
+      mu:uuid "0b18c1de-c1db-4de5-a2ad-6fd29434509e";
+      dct:title "Vlaamse Codex API Endpoint"@nl;
+      dcat:endpointURL <https://codex.opendata.api.vlaanderen.be:443/api>;
+      dct:conformsTo <https://www.w3.org/TR/json-ld11/>;
+      dcat:servesDataset <http://data.lblod.info/id/datasets/1f898ab4-1008-4701-99ed-bafa494a6910> .
   }
 }

--- a/config/migrations/20260812103000-add-vlaamse-codex-to-dcat.sparql
+++ b/config/migrations/20260812103000-add-vlaamse-codex-to-dcat.sparql
@@ -1,0 +1,69 @@
+PREFIX dcat:  <http://www.w3.org/ns/dcat#>
+PREFIX dct:   <http://purl.org/dc/terms/>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+PREFIX mu:    <http://mu.semte.ch/vocabularies/core/>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX xsd:   <http://www.w3.org/2001/XMLSchema#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/agents/3c5536f1-1427-40ff-b3a5-490897c93fa2> a foaf:Agent;
+      mu:uuid "3c5536f1-1427-40ff-b3a5-490897c93fa2";
+      vcard:hasName "Vlaamse Overheid"@nl .
+  }
+}
+;
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/services/a5d0d3ff-1593-4861-9cdc-f65d358ffa36> a dcat:DataService;
+      mu:uuid "a5d0d3ff-1593-4861-9cdc-f65d358ffa36";
+      dct:title "Vlaamse Codex"@nl;
+      dcat:endpointURL <https://codex.vlaanderen.be>;
+      dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+      dcat:servesDataset <http://data.lblod.info/id/datasets/1f898ab4-1008-4701-99ed-bafa494a6910> .
+  }
+}
+;
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/distributions/bfe864fa-4eb6-477c-9f0e-1846b5c315cb> a dcat:Distribution;
+      mu:uuid "bfe864fa-4eb6-477c-9f0e-1846b5c315cb";
+      dct:title "SPARQL Endpoint"@nl;
+      dct:issued "2026-08-12T00:00:00"^^xsd:dateTime;
+      dct:modified "2026-08-12T00:00:00"^^xsd:dateTime;
+      dcat:accessURL <https://codex.opendata.api.vlaanderen.be:8888/sparql>;
+      dcat:accessService <http://data.lblod.info/id/services/a5d0d3ff-1593-4861-9cdc-f65d358ffa36>;
+      dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
+      dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> .
+
+    <http://data.lblod.info/id/distributions/95973b1c-4275-4902-8d34-376a593326a6>
+      a dcat:Distribution;
+      mu:uuid "95973b1c-4275-4902-8d34-376a593326a6";
+      dct:title "JSON-LD API"@nl;
+      dct:issued "2026-08-12T00:00:00"^^xsd:dateTime;
+      dct:modified "2026-08-12T00:00:00"^^xsd:dateTime;
+      dcat:accessURL <https://codex.opendata.api.vlaanderen.be:443/api>;
+      dct:format <http://publications.europa.eu/resource/authority/file-type/JSON_LD>;
+      dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> .
+  }
+}
+;
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/datasets/1f898ab4-1008-4701-99ed-bafa494a6910> a dcat:Dataset;
+      mu:uuid "1f898ab4-1008-4701-99ed-bafa494a6910";
+      dct:title "Vlaamse Codex"@nl;
+      dct:description "De Vlaamse Codex bevat de geconsolideerde Vlaamse regelgeving vanaf 1 januari 1959 tot heden. De Codex vormt geen officiële bekendmaking in de zin van de Grondwet. Enkel publicatie in het Belgisch Staatsblad heeft officieel karakter."@nl;
+      dct:publisher <http://data.lblod.info/id/agents/3c5536f1-1427-40ff-b3a5-490897c93fa2>;
+      dcat:contactPoint <http://data.lblod.info/id/agents/3c5536f1-1427-40ff-b3a5-490897c93fa2>;
+      dcat:theme <http://vocab.belgif.be/auth/datatheme/GOVE>;
+      dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
+      dct:language <http://publications.europa.eu/resource/authority/language/NLD>;
+      dcat:landingPage <https://codex.vlaanderen.be>;
+      dct:issued "2026-08-12T00:00:00"^^xsd:dateTime;
+      dct:modified "2026-08-12T00:00:00"^^xsd:dateTime;
+      dcat:distribution
+          <http://data.lblod.info/id/distributions/bfe864fa-4eb6-477c-9f0e-1846b5c315cb>,
+          <http://data.lblod.info/id/distributions/95973b1c-4275-4902-8d34-376a593326a6> .
+  }
+}

--- a/config/migrations/20260812103000-add-vlaamse-codex-to-dcat.sparql
+++ b/config/migrations/20260812103000-add-vlaamse-codex-to-dcat.sparql
@@ -9,34 +9,8 @@ INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
     <http://data.lblod.info/id/agents/3c5536f1-1427-40ff-b3a5-490897c93fa2> a foaf:Agent;
       mu:uuid "3c5536f1-1427-40ff-b3a5-490897c93fa2";
-      vcard:hasName "Vlaamse Codex"@nl;
+      vcard:hasName "Vlaamse Codex";
       vcard:hasEmail "codex@vlaanderen.be".
-  }
-}
-;
-INSERT DATA {
-  GRAPH <http://mu.semte.ch/graphs/public> {
-    <http://data.lblod.info/id/distributions/bfe864fa-4eb6-477c-9f0e-1846b5c315cb> a dcat:Distribution;
-      mu:uuid "bfe864fa-4eb6-477c-9f0e-1846b5c315cb";
-      dct:title "SPARQL Endpoint"@nl;
-      dcat:accessURL <https://codex.opendata.api.vlaanderen.be:8888/sparql>;
-      dcat:accessService <http://data.lblod.info/id/services/a5d0d3ff-1593-4861-9cdc-f65d358ffa36>;
-      dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
-      dct:license <http://data.vlaanderen.be/id/licentie/modellicentie-gratis-hergebruik/v1.0>;
-      dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
-      dct:issued "2026-08-12T00:00:00"^^xsd:dateTime;
-      dct:modified "2026-08-12T00:00:00"^^xsd:dateTime.
-
-    <http://data.lblod.info/id/distributions/95973b1c-4275-4902-8d34-376a593326a6> a dcat:Distribution;
-      mu:uuid "95973b1c-4275-4902-8d34-376a593326a6";
-      dct:title "JSON-LD API"@nl;
-      dcat:accessURL <https://codex.opendata.api.vlaanderen.be:443/api>;
-      dcat:accessService <http://data.lblod.info/id/services/0b18c1de-c1db-4de5-a2ad-6fd29434509e>;
-      dct:format <http://publications.europa.eu/resource/authority/file-type/JSON_LD>;
-      dct:license <http://data.vlaanderen.be/id/licentie/modellicentie-gratis-hergebruik/v1.0>;
-      dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
-      dct:issued "2026-08-12T00:00:00"^^xsd:dateTime;
-      dct:modified "2026-08-12T00:00:00"^^xsd:dateTime.
   }
 }
 ;
@@ -44,7 +18,7 @@ INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
     <http://data.lblod.info/id/datasets/1f898ab4-1008-4701-99ed-bafa494a6910> a dcat:Dataset;
       mu:uuid "1f898ab4-1008-4701-99ed-bafa494a6910";
-      dct:title "Vlaamse Codex"@nl;
+      dct:title "Vlaamse Codex";
       dct:description "De Vlaamse Codex bevat de geconsolideerde Vlaamse regelgeving vanaf 1 januari 1959 tot heden. De Codex vormt geen officiële bekendmaking in de zin van de Grondwet. Enkel publicatie in het Belgisch Staatsblad heeft officieel karakter."@nl;
       dct:publisher <http://data.lblod.info/id/agents/3c5536f1-1427-40ff-b3a5-490897c93fa2>;
       dcat:contactPoint <http://data.lblod.info/id/agents/3c5536f1-1427-40ff-b3a5-490897c93fa2>;
@@ -53,10 +27,7 @@ INSERT DATA {
       dct:language <http://publications.europa.eu/resource/authority/language/NLD>;
       dcat:landingPage <https://codex.vlaanderen.be>;
       dct:issued "2026-08-12T00:00:00"^^xsd:dateTime;
-      dct:modified "2026-08-12T00:00:00"^^xsd:dateTime;
-      dcat:distribution
-        <http://data.lblod.info/id/distributions/bfe864fa-4eb6-477c-9f0e-1846b5c315cb>,
-        <http://data.lblod.info/id/distributions/95973b1c-4275-4902-8d34-376a593326a6>.
+      dct:modified "2026-08-12T00:00:00"^^xsd:dateTime.
   }
 }
 ;
@@ -64,15 +35,15 @@ INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
     <http://data.lblod.info/id/services/a5d0d3ff-1593-4861-9cdc-f65d358ffa36> a dcat:DataService;
       mu:uuid "a5d0d3ff-1593-4861-9cdc-f65d358ffa36";
-      dct:title "Vlaamse Codex SPARQL Endpoint"@nl;
+      dct:title "Vlaamse Codex SPARQL Endpoint";
       dcat:endpointURL <https://codex.opendata.api.vlaanderen.be:8888/sparql>;
       dct:conformsTo <https://www.w3.org/TR/sparql11-protocol/>;
       dcat:servesDataset <http://data.lblod.info/id/datasets/1f898ab4-1008-4701-99ed-bafa494a6910> .
 
     <http://data.lblod.info/id/services/0b18c1de-c1db-4de5-a2ad-6fd29434509e> a dcat:DataService;
       mu:uuid "0b18c1de-c1db-4de5-a2ad-6fd29434509e";
-      dct:title "Vlaamse Codex API Endpoint"@nl;
-      dcat:endpointURL <https://codex.opendata.api.vlaanderen.be:443/api>;
+      dct:title "Vlaamse Codex API Endpoint";
+      dcat:endpointURL <https://codex.opendata.api.vlaanderen.be:443/api/>;
       dct:conformsTo <https://www.w3.org/TR/json-ld11/>;
       dcat:servesDataset <http://data.lblod.info/id/datasets/1f898ab4-1008-4701-99ed-bafa494a6910> .
   }

--- a/config/migrations/20260812103000-add-vlaamse-codex-to-dcat.sparql
+++ b/config/migrations/20260812103000-add-vlaamse-codex-to-dcat.sparql
@@ -9,7 +9,8 @@ INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/public> {
     <http://data.lblod.info/id/agents/3c5536f1-1427-40ff-b3a5-490897c93fa2> a foaf:Agent;
       mu:uuid "3c5536f1-1427-40ff-b3a5-490897c93fa2";
-      vcard:hasName "Vlaamse Overheid"@nl .
+      vcard:hasName "Vlaamse Codex"@nl;
+      vcard:hasEmail "codex@vlaanderen.be".
   }
 }
 ;
@@ -53,7 +54,7 @@ INSERT DATA {
       dct:modified "2026-08-12T00:00:00"^^xsd:dateTime;
       dcat:distribution
         <http://data.lblod.info/id/distributions/bfe864fa-4eb6-477c-9f0e-1846b5c315cb>,
-        <http://data.lblod.info/id/distributions/95973b1c-4275-4902-8d34-376a593326a6> .
+        <http://data.lblod.info/id/distributions/95973b1c-4275-4902-8d34-376a593326a6>.
   }
 }
 ;

--- a/config/migrations/20260812103000-add-vlaamse-codex-to-dcat.sparql
+++ b/config/migrations/20260812103000-add-vlaamse-codex-to-dcat.sparql
@@ -22,6 +22,7 @@ INSERT DATA {
       dcat:accessURL <https://codex.opendata.api.vlaanderen.be:8888/sparql>;
       dcat:accessService <http://data.lblod.info/id/services/a5d0d3ff-1593-4861-9cdc-f65d358ffa36>;
       dct:format <http://publications.europa.eu/resource/authority/file-type/SPARQLQRES>;
+      dct:license <http://data.vlaanderen.be/id/licentie/modellicentie-gratis-hergebruik/v1.0>;
       dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
       dct:issued "2026-08-12T00:00:00"^^xsd:dateTime;
       dct:modified "2026-08-12T00:00:00"^^xsd:dateTime.
@@ -32,6 +33,7 @@ INSERT DATA {
       dcat:accessURL <https://codex.opendata.api.vlaanderen.be:443/api>;
       dcat:accessService <http://data.lblod.info/id/services/0b18c1de-c1db-4de5-a2ad-6fd29434509e>;
       dct:format <http://publications.europa.eu/resource/authority/file-type/JSON_LD>;
+      dct:license <http://data.vlaanderen.be/id/licentie/modellicentie-gratis-hergebruik/v1.0>;
       dct:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC>;
       dct:issued "2026-08-12T00:00:00"^^xsd:dateTime;
       dct:modified "2026-08-12T00:00:00"^^xsd:dateTime.


### PR DESCRIPTION
## Description

As we are not going to consume the sparql endpoint data and transform it to "our" ELI data we ended up adding the vlaamse code sparql endpoint to the dcat. 

In this migration we add a new dataset for Vlaamse Codex with two distributions (sparql and ld+json)


[!WARNING]
> this PR can not be merged as we do not want Freiburg, .. to also run this migration


## How to test

1. Run the migration
2. If you alrady had the frontend open kill and start the cache service again
3. Go check it out if everything looks good

## Proof

<img width="1279" height="302" alt="image" src="https://github.com/user-attachments/assets/feb2aae0-f66b-4940-b0ab-22e9bdc7cfb8" />

<img width="1616" height="822" alt="image" src="https://github.com/user-attachments/assets/8ac2918a-ed0d-4737-a285-00e91f48580d" />

