### PR TITLE
DO NOT MERGE: add local migration to add missing annotations

### DIFF
--- a/config/migrations/20260817115627-fix-missing-rmz.sparql
+++ b/config/migrations/20260817115627-fix-missing-rmz.sparql
@@ -1,0 +1,45 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX eli: <http://data.europa.eu/eli/ontology#>
+PREFIX epvoc: <https://data.europarl.europa.eu/def/epvoc#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX oa: <http://www.w3.org/ns/oa#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graph/public/pdf> {
+    ?task prov:generated ?annotation.
+    ?annotation a oa:Annotation ;
+    mu:uuid ?id ;
+    oa:hasTarget ?resource ;
+    oa:motivatedBy oa:classifying ;
+    ext:manualFixer "Karel" ;
+    dct:modified ?now ;
+    oa:hasBody <https://data.vlaanderen.be/id/concept/ZoneType/fc17fa1b-9b61-4396-a609-845643b3b865> .
+    ?container  <http://redpencil.data.gift/vocabularies/tasks/hasResource> ?annotation .
+  }
+}WHERE {
+  ?task <http://purl.org/dc/terms/isPartOf> ?job .
+  ?task <http://redpencil.data.gift/vocabularies/tasks/resultsContainer> ?container .
+  BIND(STRUUID() as ?id)
+  BIND(NOW() AS ?now)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/annotations/", ?id)) as ?annotation)
+
+  { SELECT DISTINCT ?task ?resource WHERE {
+    ?task <http://purl.org/dc/terms/isPartOf> ?job .
+    ?job dct:creator <http://redpencil.data.gift/id/scheduled-annotation-job/6A7EC00D1E6B0B9189F7662C> .
+    ?task <http://redpencil.data.gift/vocabularies/tasks/index> "2".
+    ?task <http://redpencil.data.gift/vocabularies/tasks/inputContainer> / <http://redpencil.data.gift/vocabularies/tasks/hasResource> ?resource .
+    FILTER EXISTS {
+      ?resource a eli:Expression.
+      ?resource epvoc:expressionContent ?content .
+    }
+    FILTER NOT EXISTS {
+      ?task prov:generated ?ann.
+      ?ann a oa:Annotation ;
+      oa:hasTarget ?expression ;
+      oa:motivatedBy oa:classifying ;
+      oa:hasBody <http://mu.semte.ch/vocabularies/ext/no-match-found> .
+
+    }
+  } } } 


### PR DESCRIPTION
## Description
PR to check local migration to add missing annotation

## How to test
Use the latest test dataset
Before running migrations:
check the http://dashboard.localhost/job/42f77ad3-0ac4-470d-9957-36f85a342a02/task/527612b4-97cf-11f1-b941-bd726acaa99c/results-container-resource and note that there is indeed no annotation
Then check this count for the annotations that were missing:
```
    PREFIX dct: <http://purl.org/dc/terms/>
    PREFIX eli: <http://data.europa.eu/eli/ontology#>
    PREFIX epvoc: <https://data.europarl.europa.eu/def/epvoc#>
    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
  SELECT COUNT(DISTINCT(?task)) WHERE {
        ?task <http://purl.org/dc/terms/isPartOf> ?job .
        ?job dct:creator <http://redpencil.data.gift/id/scheduled-annotation-job/6A7EC00D1E6B0B9189F7662C> .
        ?task <http://redpencil.data.gift/vocabularies/tasks/index> "2".
    ?task <http://redpencil.data.gift/vocabularies/tasks/resultsContainer> ?container .
        FILTER EXISTS {
          ?task <http://redpencil.data.gift/vocabularies/tasks/inputContainer> / <http://redpencil.data.gift/vocabularies/tasks/hasResource> ?resource .
          ?resource a eli:Expression.
          ?resource epvoc:expressionContent ?content .
        }
        FILTER NOT EXISTS {
          ?task prov:generated ?ann.
          ?ann a oa:Annotation ;
          oa:hasTarget ?expression ;
          oa:motivatedBy oa:classifying ;
          oa:hasBody <http://mu.semte.ch/vocabularies/ext/no-match-found> .
        }
      } 
      ```
Run the migrations
This query counts the annotations added in this query once it has run:
```
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>  
  SELECT count(distinct(?s)) WHERE {
    ?s ext:manualFixer "Karel"
  }
```
This count should be the same as the one from the query from before

Restart resource and cache and visit the page from before in the pipeline dashboard. It should now list the annotation. You can query that annotation by running:

```
  SELECT * WHERE {
<http://data.lblod.info/id/data-container/e548f502-407d-4ba4-8e21-6a87fc4ec67e>  ?p ?o.
  }
```

and then (uri changes depending on previous query result):

```
  SELECT * WHERE {
    <http://data.lblod.info/id/annotations/3C0A33C6-9A32-11F1-8358-9353CC2922E7> ?p ?o.
  }
```