### PR TITLE
fix missing freiburg owning body and linker setup

### DIFF
--- a/config/migrations/20260819104732-add-missing-freiburg-owning-bodies.sparql
+++ b/config/migrations/20260819104732-add-missing-freiburg-owning-bodies.sparql
@@ -1,0 +1,17 @@
+PREFIX eli: <http://data.europa.eu/eli/ontology#>
+INSERT {
+  GRAPH  <http://mu.semte.ch/graphs/public/freiburg> {
+    ?s <http://mu.semte.ch/vocabularies/ext/owningBody> <https://ris.freiburg.de/oparl/body/FR>.
+  }
+}WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public/freiburg> {
+    ?s a eli:Expression.
+
+  }
+  FILTER NOT EXISTS {
+    ?o <http://purl.org/linguistics/gold/translation> ?s.
+  }
+  FILTER NOT EXISTS {
+    ?s <http://mu.semte.ch/vocabularies/ext/owningBody> <https://ris.freiburg.de/oparl/body/FR>.
+  }
+}

--- a/config/municipality-linker/config.ts
+++ b/config/municipality-linker/config.ts
@@ -12,6 +12,7 @@ export const municipalityLink = `
       ?task <http://redpencil.data.gift/vocabularies/tasks/inputContainer> / <http://redpencil.data.gift/vocabularies/tasks/hasResource> ?decision .
       ?decision a eli:Expression.
     } UNION {
+      ?task1 <http://redpencil.data.gift/vocabularies/tasks/index> "0" .
       ?task1 <http://purl.org/dc/terms/isPartOf> ?job .
       ?task2 <http://purl.org/dc/terms/isPartOf> ?job .
       ?task1 <http://redpencil.data.gift/vocabularies/tasks/inputContainer> / <http://redpencil.data.gift/vocabularies/tasks/hasResource> ?target .
@@ -27,6 +28,20 @@ export const municipalityLink = `
       ?decision a eli:Expression.
       FILTER NOT EXISTS {
         ?original <http://purl.org/linguistics/gold/translation> ?decision .
+      }
+    } UNION {
+      BIND(<https://ris.freiburg.de/oparl/body/FR> AS ?target)
+      ?task <http://redpencil.data.gift/vocabularies/tasks/resultsContainer> / <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> / <http://purl.org/dc/terms/hasPart> / <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> ?work .
+      ?work eli:is_realized_by ?decision .
+      FILTER NOT EXISTS {
+        ?original <http://purl.org/linguistics/gold/translation> ?decision .
+      }
+
+      ?task <http://purl.org/dc/terms/isPartOf> ?job.
+      ?job <http://redpencil.data.gift/vocabularies/tasks/operation> <http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/oparl> .
+      FILTER EXISTS {
+        ?inputTask <http://purl.org/dc/terms/isPartOf> ?job.
+        ?inputTask <http://redpencil.data.gift/vocabularies/tasks/inputContainer> / <http://redpencil.data.gift/vocabularies/tasks/hasHarvestingCollection> / <http://purl.org/dc/terms/hasPart> / <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#url> <https://ris.freiburg.de/oparl> .
       }
     }
   `;


### PR DESCRIPTION
## Description
Oparl tasks don't have a municipality as input. As a result, owning body was only linked if an org was found by NEL.

This change always adds an owningbody to freiburg oparl jobs.
It also fixes the municipality linker taking too long to run because of it comparing all tasks with one another
And finally, it also adds the owningBody to the existing freiburg expressions that aren't translations

## How to test

- kill the migrations service
- run this query and note its result. It's the number of freiburg expressions without the right owning body
```
  PREFIX eli: <http://data.europa.eu/eli/ontology#>
  SELECT COUNT(DISTINCT ?s) WHERE {
    GRAPH <http://mu.semte.ch/graphs/public/freiburg> {
      ?s a eli:Expression.

    }
     FILTER NOT EXISTS {
        ?o <http://purl.org/linguistics/gold/translation> ?s.
      }
     FILTER NOT EXISTS {
        ?s <http://mu.semte.ch/vocabularies/ext/owningBody> <https://ris.freiburg.de/oparl/body/FR>.
      }
  }
```
- start a new freiburg oparl pipeline and stop it after a short time (once you have an expression)
- restart the municipality linker to be sure it runs again. Follow the logs until its done.
- now run the query above again the number should have gone down
- now start the migrations service so the other freiburg expressions are linked to an owning body
- run the query again and see the number is 0