### PR TITLE
chore: update (stored) authorisation policy

### DIFF
--- a/config/authorization/config.ttl
+++ b/config/authorization/config.ttl
@@ -399,23 +399,19 @@ ext:BesluitAdministrativeUnitAsset a odrl:Asset, sh:NodeShape ;
   sh:targetClass besluit:Bestuurseenheid .
 
 ext:DcatCatalogAsset a odrl:Asset, sh:NodeShape ;
-  odrl:partOf ext:decidePublicSlice ,
-    ext:decideHarvestingSlice ;
+  odrl:partOf ext:decidePublicSlice ;
   sh:targetClass dcat:Catalog .
 
 ext:DcatDatasetAsset a odrl:Asset, sh:NodeShape ;
-  odrl:partOf ext:decidePublicSlice ,
-    ext:decideHarvestingSlice ;
+  odrl:partOf ext:decidePublicSlice ;
   sh:targetClass dcat:Dataset .
 
 ext:DcatDataServiceAsset a odrl:Asset, sh:NodeShape ;
-  odrl:partOf ext:decidePublicSlice ,
-    ext:decideHarvestingSlice ;
+  odrl:partOf ext:decidePublicSlice ;
   sh:targetClass dcat:DataService .
 
 ext:DcatDistributionAsset a odrl:Asset, sh:NodeShape ;
-  odrl:partOf ext:decidePublicSlice ,
-    ext:decideHarvestingSlice ;
+  odrl:partOf ext:decidePublicSlice ;
   sh:targetClass dcat:Distribution .
 
 ext:DctPeriodOfTimeAsset a odrl:Asset, sh:NodeShape ;

--- a/config/migrations/insert-odrl-authorization-policy/20260821081400-chore--update-stored-authorisation-policy.sparql
+++ b/config/migrations/insert-odrl-authorization-policy/20260821081400-chore--update-stored-authorisation-policy.sparql
@@ -1,0 +1,74 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX odrl: <http://www.w3.org/ns/odrl/2/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+# Delete the resources that were removed from the ODRL policy:
+# ext:CmsPageAsset
+# ext:DctMediaTypeOrExtentAsset
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/odrl-authorization-policy> {
+    ?s ?p ?o .
+  }
+} WHERE {
+  VALUES ?s {
+    ext:CmsPageAsset
+    ext:DctMediaTypeOrExtentAsset
+  }
+  GRAPH <http://mu.semte.ch/graphs/odrl-authorization-policy> {
+    ?s ?p ?o .
+  }
+}
+;
+# Delete the triples removed from the ODRL policy
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/odrl-authorization-policy> {
+    ext:DcatCatalogAsset odrl:partOf ext:decideHarvestingSlice .
+    ext:DcatDatasetAsset odrl:partOf ext:decideHarvestingSlice .
+    ext:DcatDataServiceAsset odrl:partOf ext:decideHarvestingSlice .
+    ext:DcatDistributionAsset odrl:partOf ext:decideHarvestingSlice .
+  }
+}
+;
+# Insert resource that was added to the ODRL policy:
+# ext:DcatDataServiceAsset
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/odrl-authorization-policy> {
+    ext:DcatDataServiceAsset a odrl:Asset, sh:NodeShape ;
+                               odrl:partOf ext:decidePublicSlice ;
+                               sh:targetClass dcat:DataService .
+  }
+}
+;
+# Add/Update the dcterms:modified timestamps for added or modified resources:
+# ext:DcatDataServiceAsset
+# ext:DcatCatalogAsset
+# ext:DcatDatasetAsset
+# ext:DcatDistributionAsset
+# ext:decideAuthorizationPolicy (indirectly)
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/odrl-authorization-policy> {
+    ?s dcterms:modified ?oldModified .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/odrl-authorization-policy> {
+    ?s dcterms:modified ?now .
+  }
+} WHERE {
+  VALUES ?s {
+    ext:DcatDataServiceAsset
+    ext:DcatCatalogAsset
+    ext:DcatDatasetAsset
+    ext:DcatDistributionAsset
+    ext:decideAuthorizationPolicy
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/odrl-authorization-policy> {
+    ?s a ?type .
+    OPTIONAL {
+      ?s dcterms:modified ?oldModified .
+    }
+  }
+  BIND(NOW() AS ?now)
+}


### PR DESCRIPTION
This PR updates the ODRL authorisation policy as well as its stored version.

In the ODRL configuration, several DCAT assets were part of the slice for the harvesting graph.  This is incorrect as such resources are only located in the public graph (and some supporting graphs for the LDES).  This PR removes this incorrect links.

In [#201](https://github.com/lblod/app-decide/pull/201) two assets were removed from the ODRL policy (`ext:CmsPageAsset` and `ext:DctMediaTypeOrExtentAsset`) and one was added (`ext:DcatDataServiceAsset`).  The migration in this PR updates the stored copy of the authorisation accordingly:

- delete the removed resources;
- insert the added resource; and
- update the modified timestamps of the new affected resources.

Note that the migration also removes the `odrl:isPartOf` triples removed from the ODRL configuration.


## How to test
0. Check out this PR's branch
1. Restart the `migrations` service: `docker compose restart migrations`
2. Check that the authorisation policy graph[^1] no longer contains the `ext:CmsPageAsset` and `ext:DctMediaTypeOrExtentAsset` resources.
3. Check that the graph does contain the `ext:DcatDataServiceAsset` resource, with a modified timestamp corresponding to when you executed step 2.
4. Check that all modified resources have an updated modified timestamp.

If you also want to check whether the changes are picked up by the `ldes-delta-pusher` service, manually trigger its healing: `docker compose exec ldes-delta-pusher curl -X POST http://localhost/manual-healing`


[^1]: http://mu.semte.ch/graphs/odrl-authorization-policy