### PR TITLE
publish tombstones so we can heal deleted instances off the ldes feed

### DIFF
--- a/config/ldes-delta-pusher/config.ts
+++ b/config/ldes-delta-pusher/config.ts
@@ -32,6 +32,10 @@ type LdesConfig = {
 
 export const streams: LdesConfig = {
   public: {
+    'http://www.w3.org/ns/activitystreams#Tombstone': {
+      graphFilter: PUBLIC_GRAPH_FILTER,
+      healingPredicates: [HEALING_PREDICATE],
+    },
     'http://www.w3.org/ns/dcat#Catalog': {
       graphFilter: PUBLIC_GRAPH_FILTER,
       healingPredicates: [HEALING_PREDICATE],


### PR DESCRIPTION
## Description
Tombstones were not published to ldes feed but they should be as they are used to mark deleted entities.
After this PR, tombstones will be published on the ldes feed

## How to test
Take the latest test data
LOCALLY remove your ldes data: `rm -rf data/ldes-feed/public/* `
LOCALLY republish your ldes from scratch by restarting ldes-delta-pusher with:
```
ldes-delta-pusher:
    environment:
      WRITE_INITIAL_STATE: "true"
```
LOCALLY delete a published dataset or distribution from the ldes feed, e.g.
```
DELETE WHERE {
  GRAPH ?g {
     <http://data.lblod.info/id/datasets/8f98549f-163e-51ba-bcd4-33c7432944d0> ?p ?o.
   }
}
```
Then heal you ldes delta pusher (twice so if your deltanotifier is broken, it will auto-heal tombstones too):
```
 docker compose exec ldes-delta-pusher curl -X POST http://localhost/manual-healing 
```

You should now see the removed dataset show up as a tombstone in your last ldes page.