### PR TITLE
make sure we can publish datasets again if there are tombstones around for them

### DIFF
--- a/scripts/project/publish_dataset/helpers.py
+++ b/scripts/project/publish_dataset/helpers.py
@@ -131,8 +131,8 @@ def select_rows(q: str) -> list[dict]:
     return [{k: v["value"] for k, v in row.items()} for row in bindings]
 
 
-def graph_has_subject(subject: str, graph: str) -> bool:
-    return query(f"ASK {{ GRAPH <{graph}> {{ <{subject}> ?p ?o . }} }}")["boolean"]
+def graph_has_type(subject: str, thing: str, graph: str) -> bool:
+    return query(f"ASK {{ GRAPH <{graph}> {{ <{subject}> a <{thing}> . }} }}")["boolean"]
 
 
 def get_issued(subject: str, graph: str) -> str | None:

--- a/scripts/project/publish_dataset/lib/generate_dcat.py
+++ b/scripts/project/publish_dataset/lib/generate_dcat.py
@@ -5,15 +5,20 @@ env = Environment(loader=FileSystemLoader("."))
 from helpers import graph_has_type, delete_subjects, turtle_to_insert_data, update, log, delete_linked_resources, delete_reverse_linked_resources
 from config import datadump_file_name, dataset_uri_and_uuid, distribution_uri_and_uuid, service_uri_and_uuid, PUBLIC_GRAPH
 
+DCAT_CATALOG = "http://www.w3.org/ns/dcat#Catalog"
+DCAT_DATASET = "http://www.w3.org/ns/dcat#Dataset"
+DCAT_DISTRIBUTION = "http://www.w3.org/ns/dcat#Distribution"
+DCAT_DATASERVICE = "http://www.w3.org/ns/dcat#DataService"
+
 def step1_write_catalog(organization: str, organization_config: dict, now_iso: str) -> None:
     log("[Step 1] Generate DCAT Catalog for %s", organization)
     catalog_uri = organization_config["catalog_uri"]
     catalog_publisher_uri = organization_config["catalog_publisher"].get("uri")
     
-    if graph_has_type(catalog_uri, "http://www.w3.org/ns/dcat#Catalog", PUBLIC_GRAPH):
+    if graph_has_type(catalog_uri, DCAT_CATALOG, PUBLIC_GRAPH):
         log("Catalog '%s' already exists in <%s>, doing nothing.", organization, PUBLIC_GRAPH)
     else:
-        delete_subjects([catalog_uri]) # in case there is a tombstone for it
+        delete_subjects([catalog_uri], PUBLIC_GRAPH) # in case there is a tombstone for it or any other information that claims it is some other type than a catalog
         catalog_template = env.get_template("templates/dcat-catalog.ttl.j2")
         catalog_output = catalog_template.render(
             ISSUED=now_iso,
@@ -32,12 +37,12 @@ def step2_write_dataset(organization: str, organization_config: dict, dataset: s
     insert_dataset = True
     insert_dataservice = True
     insert_distribution = True
-    if graph_has_type(dataset_uri, "http://www.w3.org/ns/dcat#Dataset", PUBLIC_GRAPH):
+    if graph_has_type(dataset_uri, DCAT_DATASET, PUBLIC_GRAPH):
         log("DCAT Dataset '%s' already exists in <%s>, only appending link to the service and distribution if they don't exist yet.", dataset, PUBLIC_GRAPH)
         insert_dataset = False
-        if graph_has_type(service_uri, "http://www.w3.org/ns/dcat#DataService", PUBLIC_GRAPH):
+        if graph_has_type(service_uri, DCAT_DATASERVICE, PUBLIC_GRAPH):
             insert_dataservice = False
-        if graph_has_type(distribution_uri, "http://www.w3.org/ns/dcat#Distribution", PUBLIC_GRAPH):
+        if graph_has_type(distribution_uri, DCAT_DISTRIBUTION, PUBLIC_GRAPH):
             insert_distribution = False
     
     values_to_delete = []

--- a/scripts/project/publish_dataset/lib/generate_dcat.py
+++ b/scripts/project/publish_dataset/lib/generate_dcat.py
@@ -2,18 +2,18 @@ from datetime import datetime
 from jinja2 import Environment, FileSystemLoader
 env = Environment(loader=FileSystemLoader("."))
 
-from helpers import graph_has_subject, turtle_to_insert_data, update, log, delete_linked_resources, delete_reverse_linked_resources
+from helpers import graph_has_type, delete_subjects, turtle_to_insert_data, update, log, delete_linked_resources, delete_reverse_linked_resources
 from config import datadump_file_name, dataset_uri_and_uuid, distribution_uri_and_uuid, service_uri_and_uuid, PUBLIC_GRAPH
 
 def step1_write_catalog(organization: str, organization_config: dict, now_iso: str) -> None:
     log("[Step 1] Generate DCAT Catalog for %s", organization)
     catalog_uri = organization_config["catalog_uri"]
     catalog_publisher_uri = organization_config["catalog_publisher"].get("uri")
-    catalog_subjects = [catalog_uri] + ([catalog_publisher_uri] if catalog_publisher_uri else [])
-
-    if graph_has_subject(catalog_uri, PUBLIC_GRAPH):
+    
+    if graph_has_type(catalog_uri, "http://www.w3.org/ns/dcat#Catalog", PUBLIC_GRAPH):
         log("Catalog '%s' already exists in <%s>, doing nothing.", organization, PUBLIC_GRAPH)
     else:
+        delete_subjects([catalog_uri]) # in case there is a tombstone for it
         catalog_template = env.get_template("templates/dcat-catalog.ttl.j2")
         catalog_output = catalog_template.render(
             ISSUED=now_iso,
@@ -32,13 +32,23 @@ def step2_write_dataset(organization: str, organization_config: dict, dataset: s
     insert_dataset = True
     insert_dataservice = True
     insert_distribution = True
-    if graph_has_subject(dataset_uri, PUBLIC_GRAPH):
+    if graph_has_type(dataset_uri, "http://www.w3.org/ns/dcat#Dataset", PUBLIC_GRAPH):
         log("DCAT Dataset '%s' already exists in <%s>, only appending link to the service and distribution if they don't exist yet.", dataset, PUBLIC_GRAPH)
         insert_dataset = False
-        if graph_has_subject(service_uri, PUBLIC_GRAPH):
+        if graph_has_type(service_uri, "http://www.w3.org/ns/dcat#DataService", PUBLIC_GRAPH):
             insert_dataservice = False
-        if graph_has_subject(distribution_uri, PUBLIC_GRAPH):
+        if graph_has_type(distribution_uri, "http://www.w3.org/ns/dcat#Distribution", PUBLIC_GRAPH):
             insert_distribution = False
+    
+    values_to_delete = []
+    if insert_dataset:
+        values_to_delete.append(dataset_uri)
+    if insert_dataservice:
+        values_to_delete.append(service_uri)
+    if insert_distribution:
+        values_to_delete.append(distribution_uri)
+    if values_to_delete:
+        delete_subjects(values_to_delete, PUBLIC_GRAPH)
 
     datadump_base_url = organization_config.get("datadump_base_url")
     output_file_name = dataset_config.get("output_file_name", dataset)


### PR DESCRIPTION
## Description
This fixes the fact that the publication script is unwilling to republish a dataset/distribution/service if a tombstone exists for its uri. These tombstones are automatically erected if such an instance is deleted by the healing of the ldes feed, but they shouldn't prevent the instance coming back from the dead.

## How to test
- take the dataset from the test environment
- use this query to remove the HVT annotations for gent:
```
    DELETE {
       GRAPH ?g {
        ?s ?p ?o.
      }
    }WHERE {
      VALUES ?s {
        <http://data.lblod.info/id/datasets/79f9ed1c-94cb-5a77-a17e-af9a192acfcb>
  <http://data.lblod.info/id/services/e433ecf7-e3c1-5c02-87d2-1829a0db838f>
  <http://data.lblod.info/id/distributions/b0687254-5c9d-553a-90f9-f7fb23e630fb>

        }
      GRAPH ?g {
        ?s ?p ?o.
      }
    }
```
- heal the ldes so the tombstones are erected: `docker compose exec ldes-delta-pusher curl -X POST http://localhost/manual-healing`
- manually add the sparql endpoint and dataset to the gent dataset in the publication config so its distribution and service are created again: 
```
      "sparql_endpoint": "http://ds.decide.lblod.info/api/sparql",
      "datadump_base_url": "http://ds.decide.lblod.info/datadumps/"
``` 
- republish the dataset: `mu script project-scripts publish-dataset --dataset human-validations --org gent`
- the dataset is now present in the dcat and the ldes