### PR TITLE
Prevent values containing newlines in exported CSVs

### DIFF
--- a/scripts/project/export_csv/export_csv.py
+++ b/scripts/project/export_csv/export_csv.py
@@ -58,7 +58,8 @@ def select_rows_with_vars(q: str) -> tuple[list[str], list[dict]]:
     result = query(q)
     variables = result["head"]["vars"]
     rows = [
-        {k: _format_binding(v) for k, v in row.items()} for row in result["results"]["bindings"]
+        {k: _format_binding(v) for k, v in row.items()}
+        for row in result["results"]["bindings"]
     ]
     return variables, rows
 

--- a/scripts/project/export_csv/export_csv.py
+++ b/scripts/project/export_csv/export_csv.py
@@ -47,7 +47,8 @@ _COMMA_DECIMAL_DATATYPES = {
 
 
 def _format_binding(binding: dict) -> str:
-    value = binding["value"]
+    # Strip embedded newlines (since Excel splits quoted multi-line fields into extra rows)
+    value = binding["value"].replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
     if binding.get("datatype") in _COMMA_DECIMAL_DATATYPES:
         return value.replace(".", ",")
     return value


### PR DESCRIPTION
After importing a CSV file resulting from the `export_csv` script, in Excel, it became clear that some records were handled incorrectly. Specifically, some were spread over multiple rows. E.g.:
<img width="1616" height="164" alt="image" src="https://github.com/user-attachments/assets/a7930314-deb2-41c5-8d1b-2d427310acfd" />

The cause were newlines characters in string fields. They lead to extra rows in the original CSV files. E.g.:
```csv
expression;titelBesluit;datumBesluit;conceptScheme;conceptSchemeLabel;concept;conceptLabel;impact;creator;positief;negatief;gemeente;organisatie;organisatieAfgeleid
https://data.gent.be/id/besluiten/23.0914.7908.2224;"2023_CBS_09179 - OMV_2023108881 - aanvraag omgevingsvergunning voor het exploiteren van een bemaling betreffende de verwijdering van een gedeelte van de
bestaande leidingen en het aanleggen van twee nieuwe aardgasleidingen inclusief aanhorigheden in opdracht van Fluxys + bijstelling  - zonder openbaar onderzoek  - Knippegroen, 9042 Sint-Kruis-Winkel - Advies";2023-09-22;http://lblod.data.gift/id/conceptscheme/restricted-mobility-zone-simple;Restricted Mobility Zones;http://mu.semte.ch/vocabularies/ext/no-match-found;No Match Found;;http://lblod.data.gift/id/components/b0d4b9f5-24bc-448d-84a3-ac583a6272f2/model_annotator;0;0;Gent;College van Burgemeester en Schepenen Gent;
```

While the CSV spec does in fact allow newlines in quoted fields (RFC 4180), it is know that Excel doesn't handle those cases properly. That's why this PR updates the `export_csv` logic slightly to replace any newline or tab characters in strings with spaces. That leads to the same CSV record looking like this:
```csv
expression;titelBesluit;datumBesluit;conceptScheme;conceptSchemeLabel;concept;conceptLabel;impact;creator;positief;negatief;gemeente;organisatie;organisatieAfgeleid
https://data.gent.be/id/besluiten/23.0914.7908.2224;2023_CBS_09179 - OMV_2023108881 - aanvraag omgevingsvergunning voor het exploiteren van een bemaling betreffende de verwijdering van een gedeelte van de bestaande leidingen en het aanleggen van twee nieuwe aardgasleidingen inclusief aanhorigheden in opdracht van Fluxys + bijstelling  - zonder openbaar onderzoek  - Knippegroen, 9042 Sint-Kruis-Winkel - Advies;2023-09-22;http://lblod.data.gift/id/conceptscheme/sdg-simple;Sustainable Development Goals;http://lblod.data.gift/id/concept/4ae4f35a793e96bb0809305988daf35a;Make cities and human settlements inclusive, safe, resilient and sustainable;Positive;http://lblod.data.gift/id/components/95be7ccb-ed60-4130-8e25-be81f77d4d43/model_annotator;0;0;Gent;College van Burgemeester en Schepenen Gent;
```

And indeed, Excel correctly parses this as a single row:
<img width="1523" height="88" alt="image" src="https://github.com/user-attachments/assets/ea386c97-5822-4e5a-a87e-ab337569a66d" />
