### PR TITLE
docs: fix model versions to medium 3.5 instead of medium latest

### DIFF
--- a/config/ner/config.bamberg.json
+++ b/config/ner/config.bamberg.json
@@ -37,7 +37,7 @@
     },
     "langchain": {
       "provider": "mistralai",
-      "model_name": "mistral-medium-latest",
+      "model_name": "mistral-medium-3-5",
       "base_url": "https://core.ayunis.com/api/openai-compat/v1",
       "temperature": 0.1,
       "max_text_length": 6000
@@ -46,7 +46,7 @@
   "segmentation": {
     "llm": {
       "provider": "mistralai",
-      "model_name": "mistral-medium-latest",
+      "model_name": "mistral-medium-3-5",
       "base_url": "https://core.ayunis.com/api/openai-compat/v1",
       "temperature": 0.1
     },

--- a/config/pdf-content/config.bamberg.json
+++ b/config/pdf-content/config.bamberg.json
@@ -22,7 +22,7 @@
   "segmentation": {
     "llm": {
       "provider": "mistralai",
-      "model_name": "mistral-medium-latest",
+      "model_name": "mistral-medium-3-5",
       "base_url": "https://core.ayunis.com/api/openai-compat/v1",
       "temperature": 0.1
     },


### PR DESCRIPTION
Some model refs were set on "latest". 
Update these to use the exact model version that is being used